### PR TITLE
Update ND Supporting Document 2_2.adoc

### DIFF
--- a/ND Supporting Document 2_2.adoc
+++ b/ND Supporting Document 2_2.adoc
@@ -2648,7 +2648,7 @@ Remark: Some systems might require the presence of the SAN extension. In this ca
 [arabic, start=550]
 . Test 1 [conditional]: If the TOE presents the Supported Elliptic Curves/Supported Groups Extension, _the evaluator shall configure the server to perform ECDHE or DHE (as applicable) key exchange using each of the TOE’s supported curves and/or groups. The evaluator shall verify that the TOE successfully connects to the server.
 
-==== FCS_TLSS_EXT.1 Extended: TLS Server Protocol without mutual authentication
+==== FCS_TLSS_EXT.1 Extended: TLS Server Protocol
 
 ===== TSS
 
@@ -2676,7 +2676,9 @@ Remark: Some systems might require the presence of the SAN extension. In this ca
 
 [arabic, start=555]
 . The evaluator shall verify that the TSS describes if session resumption based on session IDs is supported (RFC 4346 and/or RFC 5246), if session resumption based on session tickets is supported (RFC 5077) and/or if session resumption according to RFC8446 is supported.
+
 . If session tickets are supported, the evaluator shall verify that the TSS describes that the session tickets are encrypted using symmetric algorithms consistent with FCS_COP.1/DataEncryption. The evaluator shall verify that the TSS identifies the key lengths and algorithms used to protect session tickets.
+
 . If session tickets are supported, the evaluator shall verify that the TSS describes that session tickets adhere to the structural format provided in section 4 of RFC 5077 and if not, a justification shall be given of the actual session ticket format.
 
 *FCS_TLSS_EXT.1.6*
@@ -2684,7 +2686,7 @@ Remark: Some systems might require the presence of the SAN extension. In this ca
 [arabic, start=556]
 . The evaluator shall verify that TSS describes whether the list of supported ciphersuites can be configured or not.
 
-*FCS_TLSS_EXT.1.7*
+*FCS_TLSS_EXT.1.8*
 
 [arabic, start=557]
 . The evaluator shall verify in the TSS that, for TLS 1.3, the TOE shall not permit out-of-band provisioning of pre-shared keys (PSKs) in the evaluated configuration.
@@ -2711,10 +2713,10 @@ Remark: Some systems might require the presence of the SAN extension. In this ca
 [arabic, start=559]
 . If the TSF provides the ability of configuring the list of supported ciphersuites, the evaluator shall verify that AGD guidance includes configuration of the list of supported ciphersuites.
 
-*FCS_TLSS_EXT.1.7*
+*FCS_TLSS_EXT.1.8*
 
 [arabic, start=559]
-. If the TSF provides the ability of configuring the list of supported ciphersuites, the evaluator shall verify that AGD guidance includes configuration of the list of supported ciphersuites.
+. The evaluator shall verify that any configuration necessary to meet the requirement must be contained in the AGD guidance.
 
 ===== Tests
 

--- a/ND Supporting Document 2_2.adoc
+++ b/ND Supporting Document 2_2.adoc
@@ -2686,7 +2686,7 @@ Remark: Some systems might require the presence of the SAN extension. In this ca
 [arabic, start=556]
 . The evaluator shall verify that TSS describes whether the list of supported ciphersuites can be configured or not.
 
-*FCS_TLSS_EXT.1.8*
+*FCS_TLSS_EXT.1.7*
 
 [arabic, start=557]
 . The evaluator shall verify in the TSS that, for TLS 1.3, the TOE shall not permit out-of-band provisioning of pre-shared keys (PSKs) in the evaluated configuration.
@@ -2713,7 +2713,7 @@ Remark: Some systems might require the presence of the SAN extension. In this ca
 [arabic, start=559]
 . If the TSF provides the ability of configuring the list of supported ciphersuites, the evaluator shall verify that AGD guidance includes configuration of the list of supported ciphersuites.
 
-*FCS_TLSS_EXT.1.8*
+*FCS_TLSS_EXT.1.7*
 
 [arabic, start=559]
 . The evaluator shall verify that any configuration necessary to meet the requirement must be contained in the AGD guidance.

--- a/ND Supporting Document 2_2.adoc
+++ b/ND Supporting Document 2_2.adoc
@@ -2660,36 +2660,61 @@ Remark: Some systems might require the presence of the SAN extension. In this ca
 *FCS_TLSS_EXT.1.2*
 
 [arabic, start=552]
-. The evaluator shall verify that the TSS contains a description of how the TOE technically prevents the use of old SSL and TLS versions.
+. The evaluator shall verify that the TSS contains a description of how the TOE technically prevents the use of unsupported and undefined SSL and TLS versions.
 
 *FCS_TLSS_EXT.1.3*
 
 [arabic, start=553]
-. If using ECDHE or DHE ciphers, the evaluator shall verify that the TSS describes the key agreement parameters of the server Key Exchange message.
+. If using ECDHE or DHE ciphers, the evaluator shall verify that the TSS describes the algorithms and key sizes the TSF supports for authenticating itself to TLS clients. The evaluator shall ensure these algorithms are consistent with the selected ciphersuites.
 
 *FCS_TLSS_EXT.1.4*
 
 [arabic, start=554]
-. The evaluator shall verify that the TSS describes if session resumption based on session IDs is supported (RFC 4346 and/or RFC 5246) and/or if session resumption based on session tickets is supported (RFC 5077).
+. The evaluator shall verify that the TSS describes the key exchange parameters of the server Key Exchange message. The evaluator shall ensure these algorithms are consistent with the selected ciphersuites.
+
+*FCS_TLSS_EXT.1.5*
+
+[arabic, start=555]
+. The evaluator shall verify that the TSS describes if session resumption based on session IDs is supported (RFC 4346 and/or RFC 5246), if session resumption based on session tickets is supported (RFC 5077) and/or if session resumption according to RFC8446 is supported.
 . If session tickets are supported, the evaluator shall verify that the TSS describes that the session tickets are encrypted using symmetric algorithms consistent with FCS_COP.1/DataEncryption. The evaluator shall verify that the TSS identifies the key lengths and algorithms used to protect session tickets.
 . If session tickets are supported, the evaluator shall verify that the TSS describes that session tickets adhere to the structural format provided in section 4 of RFC 5077 and if not, a justification shall be given of the actual session ticket format.
+
+*FCS_TLSS_EXT.1.6*
+
+[arabic, start=556]
+. The evaluator shall verify that TSS describes whether the list of supported ciphersuites can be configured or not.
+
+*FCS_TLSS_EXT.1.7*
+
+[arabic, start=557]
+. The evaluator shall verify in the TSS that, for TLS 1.3, the TOE shall not permit out-of-band provisioning of pre-shared keys (PSKs) in the evaluated configuration.
 
 ===== Guidance Documentation
 
 *FCS_TLSS_EXT.1.1*
 
 [arabic, start=557]
-. The evaluator shall check the guidance documentation to ensure that it contains instructions on configuring the TOE so that TLS conforms to the description in the TSS (for instance, the set of ciphersuites advertised by the TOE may have to be restricted to meet the requirements).
+. The evaluator shall check the guidance documentation to ensure that it contains instructions on configuring the TOE so that TLS conforms to the description in the TSS (for instance, the set of ciphersuites advertised by the TOE or TLS version supported by the TOE may have to be restricted to meet the requirements).
 
-*FCS_TLSS_EXT.1.2*
+*FCS_TLSS_EXT.1.3*
 
 [arabic, start=558]
 . The evaluator shall verify that any configuration necessary to meet the requirement must be contained in the AGD guidance.
 
-*FCS_TLSS_EXT.1.3*
+*FCS_TLSS_EXT.1.4*
+
+[arabic, start=558]
+. The evaluator shall verify that any configuration necessary to meet the requirement must be contained in the AGD guidance.
+
+*FCS_TLSS_EXT.1.6*
 
 [arabic, start=559]
-. The evaluator shall verify that any configuration necessary to meet the requirement must be contained in the AGD guidance.
+. If the TSF provides the ability of configuring the list of supported ciphersuites, the evaluator shall verify that AGD guidance includes configuration of the list of supported ciphersuites.
+
+*FCS_TLSS_EXT.1.7*
+
+[arabic, start=559]
+. If the TSF provides the ability of configuring the list of supported ciphersuites, the evaluator shall verify that AGD guidance includes configuration of the list of supported ciphersuites.
 
 ===== Tests
 
@@ -2697,43 +2722,56 @@ Remark: Some systems might require the presence of the SAN extension. In this ca
 
 [arabic, start=560]
 . Test 1: The evaluator shall establish a TLS connection using each of the ciphersuites specified by the requirement. This connection may be established as part of the establishment of a higher-level protocol, e.g., as part of an HTTPS session. It is sufficient to observe the successful negotiation of a ciphersuite to satisfy the intent of the test; it is not necessary to examine the characteristics of the encrypted traffic to discern the ciphersuite being used (for example, that the cryptographic algorithm is 128-bit AES and not 256-bit AES).
-. Test 2: The evaluator shall send a Client Hello to the server with a list of ciphersuites that does not contain any of the ciphersuites in the server’s ST and verify that the server denies the connection. Additionally, the evaluator shall send a Client Hello to the server containing only the TLS_NULL_WITH_NULL_NULL ciphersuite and verify that the server denies the connection.
+. Test 2: The evaluator shall perform the following tests:
+.. The evaluator shall send a Client Hello to the server with a list of ciphersuites that does not contain any of the ciphersuites in the server’s ST and verify that the server denies the connection. 
+.. [conditional]: Perform this test only if support of TLSv1.1 or TLSv1.2 is claimed. The evaluator shall send a Client Hello to the server containing only the TLS_NULL_WITH_NULL_NULL ciphersuite and verify that the server denies the connection.
 . Test 3: The evaluator shall perform the following modifications to the traffic:
 [loweralpha]
-.. Modify a byte in the Client Finished handshake message, and verify that the server rejects the connection and does not send any application data.
+.. [conditional]: Perform this test only if support of TLSv1.1 or TLSv1.2 is claimed. Modify a byte in the Client Finished handshake message, and verify that the server rejects the connection and does not send any application data.
 .. (Test Intent: The intent of this test is to ensure that the server's TLS implementation immediately makes use of the key exchange and authentication algorithms to: a) Correctly encrypt (D)TLS Finished message and b) Encrypt every (D)TLS message after session keys are negotiated.)
 +
 
-The evaluator shall use one of the claimed ciphersuites to complete a successful handshake and observe transmission of properly encrypted application data. The evaluator shall verify that no Alert with alert level Fatal (2) messages were sent.
+[conditional]: Perform this test only if support of TLSv1.1 or TLSv1.2 is claimed. The evaluator shall use one of the claimed ciphersuites to complete a successful handshake and observe transmission of properly encrypted application data. The evaluator shall verify that no Alert with alert level Fatal (2) messages were sent.
 +
 
 The evaluator shall verify that the Finished message (Content type hexadecimal 16 and handshake message type hexadecimal 14) is sent immediately after the server's ChangeCipherSpec (Content type hexadecimal 14) message. The evaluator shall examine the Finished message (encrypted example in hexadecimal of a TLS record containing a Finished message, 16 03 03 00 40 11 22 33 44 55...) and confirm that it does not contain unencrypted data (unencrypted example in hexadecimal of a TLS record containing a Finished message, 16 03 03 00 40 14 00 00 0c...), by verifying that the first byte of the encrypted Finished message does not equal hexadecimal 14 for at least one of three test messages. There is a chance that an encrypted Finished message contains a hexadecimal value of '14' at the position where a plaintext Finished message would contain the message type code '14'. If the observed Finished message contains a hexadecimal value of '14' at the position where the plaintext Finished message would contain the message type code, the test shall be repeated three times in total. In case the value of '14' can be observed in all three tests it can be assumed that the Finished message has indeed been sent in plaintext and the test has to be regarded as 'failed'. Otherwise it has to be assumed that the observation of the value '14' has been due to chance and that the Finished message has indeed been sent encrypted. In that latter case the test shall be regarded as 'passed'.
 
+.. [conditional]: Perform this test only if support of TLSv1.3 is claimed. The evaluator shall use a client to send a Client Hello message containing a single curve in the Supported Groups extension. The curve that is selected to be presented in this extension should not be supported by the TOE. The evaluator shall verify that the TOE disconnects after receiving the Client Hello message.
+
+.. [conditional]: Perform this test only if support of TLSv1.3 is claimed. The evaluator shall use a client to send a Client Hello message containing a multiple curves in the Supported Groups extension. These curves should be chosen such that only one of these curves is supported by the TOE. The evaluator shall verify that the TOE responds with a Hello Retry Request message selecting the supported curve. This shall be reflected in the Key Share extension of the Hello Retry Request message.
+
 *FCS_TLSS_EXT.1.2*
 
 [arabic, start=563]
-. The evaluator shall send a Client Hello requesting a connection for all mandatory and selected protocol versions in the SFR (e.g. by enumeration of protocol versions in a test client) and verify that the server denies the connection for each attempt.
+. Test 1: The evaluator shall attempt to establish a TLS/SSL connection using each of the TLS/SSL versions (i.e., TLS1.3, TLS1.2, TLS1.1, TLS1.0, SSL3.0, SSL2.0). The client shall be configured so it only supports the version being tested. The evaluator shall verify that the versions specified in FCS_TLSS_EXT.1.1 are successfully established and all other versions not successfully established. If the TOE attempts to downgrade the version, it is acceptable for the test client to terminate the connection; however, the version selected by the TOE shall always be a version specified in FCS_TLSS_EXT.1.1.
 
-*FCS_TLSS_EXT.1.3*
+*FCS_TLSS_EXT.1.3 and FCS_TLSS_EXT.1.4*
 
 [arabic, start=564]
-. Test 1: [conditional] If ECDHE ciphersuites are supported:
+. Test 1: [conditional] If ECDHE ciphersuites/group are supported:
 [loweralpha]
-.. The evaluator shall repeat this test for each supported elliptic curve. The evaluator shall attempt a connection using a supported ECDHE ciphersuite and a single supported elliptic curve specified in the Elliptic Curves Extension. The Evaluator shall verify (though a packet capture or instrumented client) that the TOE selects the same curve in the Server Key Exchange message and successfully establishes the connection.
-.. The evaluator shall attempt a connection using a supported ECDHE ciphersuite and a single unsupported elliptic curve (e.g. secp192r1 (0x13)) specified in RFC4492, chap. 5.1.1. The evaluator shall verify that the TOE does not send a Server Hello message and the connection is not successfully established.
-. Test 2: [conditional] If DHE ciphersuites are supported, the evaluator shall repeat the following test for each supported parameter size. If any configuration is necessary, the evaluator shall configure the TOE to use a supported Diffie-Hellman parameter size. The evaluator shall attempt a connection using a supported DHE ciphersuite. The evaluator shall verify (through a packet capture or instrumented client) that the TOE sends a Server Key Exchange Message where p Length is consistent with the message are the ones configured Diffie-Hellman parameter size(s).
+.. The evaluator shall repeat this test for each supported elliptic curve. The evaluator shall attempt a connection using a supported ECDHE ciphersuite (TLSv1.1/v1.2) or group (TLSv1.3) and a single supported elliptic curve specified in the supported groups extension. The Evaluator shall verify (through a packet capture or instrumented client) that the TOE selects the same curve in the Server Key Exchange (TLSv1.1/v1.2) or Server Hello (key_share, for TLSv1.3) message and successfully establishes the connection.
+.. The evaluator shall attempt a connection using a supported ECDHE ciphersuite (TLSv1.1/1.2) or group (TLSv1.3) and a single unsupported elliptic curve (e.g. secp192r1 (0x13)) specified in RFC4492, chap. 5.1.1. The evaluator shall verify that the TOE does not send a Server Hello message and the connection is not successfully established.
+. Test 2: [conditional] If DHE ciphersuites are supported, the evaluator shall repeat the following test for each supported parameter size. If any configuration is necessary, the evaluator shall configure the TOE to use a supported Diffie-Hellman parameter size. The evaluator shall attempt a connection using a supported DHE ciphersuite. 
++
+
+For TLS1.1 and TLS.1.2, the evaluator shall verify (through a packet capture or instrumented client) that the TOE sends a Server Key Exchange Message where p Length is consistent with the message are the ones configured Diffie-Hellman parameter size(s).
++
+
+For TLS1.3, the evaluator shall verify (through a packet capture or instrumented client) that the TOE sends a Server Key Share Extension Message where the KeyShareServerHello structure contains a KeyShareEntry structure with an opaque key_exchange value whose Length is consistent with the configured Diffie-Hellman parameter size(s). 
+
 . Test 3: [conditional] If RSA key establishment ciphersuites are supported, the evaluator shall repeat this test for each RSA key establishment key size. If any configuration is necessary, the evaluator shall configure the TOE to perform RSA key establishment using a supported key size (e.g. by loading a certificate with the appropriate key size). The evaluator shall attempt a connection using a supported RSA key establishment ciphersuite. The evaluator shall verify (through a packet capture or instrumented client) that the TOE sends a certificate whose modulus is consistent with the configured RSA key size.
 
-*FCS_TLSS_EXT.1.4*
+*FCS_TLSS_EXT.1.5*
 
 _Test Objective: To demonstrate that the TOE will not resume a session for which the client failed to complete the handshake (independent of TOE support for session resumption)._
 
 [arabic, start=567]
-. Test 1 [conditional]: If the TOE does not support session resumption based on session IDs according to RFC4346 (TLS1.1) or RFC5246 (TLS1.2) or session tickets according to RFC5077, the evaluator shall perform the following test:
+. Test 1 [conditional]: If the TOE does not support session resumption based on session IDs according to RFC4346 (TLS1.1) or RFC5246 (TLS1.2) or session tickets according to RFC5077 (TLS1.2) or session resumption according to RFC8446 (TLS1.3), the evaluator shall perform the following test:
 [loweralpha]
-.. The client sends a Client Hello with a zero-length session identifier and with a SessionTicket extension containing a zero-length ticket.
+.. For all supported TLS versions the client shall send a Client Hello with a zero-length session identifier and with a SessionTicket extension containing a zero-length ticket. A non-zero length session identifier for TLSv1.3 would result in testing compatibility mode which is not the objective of this test. For TLSv1.3, the evaluator shall ensure that a 'psk_key_exchange_modes' extension is included in the Client Hello.
 .. The client verifies the server does not send a NewSessionTicket handshake message (at any point in the handshake).
-.. The client verifies the Server Hello message contains a zero-length session identifier or passes the following steps:
+.. The client verifies the Server Hello message contains a zero-length session identifier. For TLSv1.1 and TLSv1.2 the client could alternatively pass the following steps (not applicable for TLSv1.3):
 +
 Note: The following steps are only performed if the ServerHello message contains a non-zero length SessionID.
 [loweralpha, start=4]
@@ -2744,14 +2782,31 @@ Note: The following steps are only performed if the ServerHello message contains
 [arabic, start=568]
 . Test 2 [conditional]: If the TOE supports session resumption using session IDs according to RFC4346 (TLS1.1) or RFC5246 (TLS1.2), the evaluator shall carry out the following steps (note that for each of these tests, it is not necessary to perform the test case for each supported version of TLS):
 [loweralpha]
-.. The evaluator shall conduct a successful handshake and capture the TOE-generated session ID in the Server Hello message. The evaluator shall then initiate a new TLS connection and send the previously captured session ID to show that the TOE resumed the previous session by responding with ServerHello containing the same SessionID immediately followed by ChangeCipherSpec and Finished messages (as shown in Figure 2 of RFC 4346 or RFC 5246).
+.. The evaluator shall conduct a successful handshake and capture the TOE-generated session ID in the Server Hello message. The evaluator shall then initiate a new TLS connection and send the previously captured session ID to show that the TOE resumed the previous session by responding with ServerHello containing the same SessionID immediately followed by ChangeCipherSpec and Finished messages (as shown in Figure 2 of RFC 4346 or RFC 5246). When the session is resumed, the evaluator shall verify on the TLS Client used for performing this test, that the TOE (TLS Server) has not advertised support for the early data extension. 
 .. The evaluator shall initiate a handshake and capture the TOE-generated session ID in the Server Hello message. The evaluator shall then, within the same handshake, generate or force an unencrypted fatal Alert message immediately before the client would otherwise send its ChangeCipherSpec message thereby disrupting the handshake. The evaluator shall then initiate a new Client Hello using the previously captured session ID, and verify that the server (1) implicitly rejects the session ID by sending a ServerHello containing a different SessionID and performing a full handshake (as shown in figure 1 of RFC 4346 or RFC 5246), or (2) terminates the connection in some way that prevents the flow of application data.
 
 [arabic, start=569]
-. Test 3 [conditional]: If the TOE supports session tickets according to RFC5077, the evaluator shall carry out the following steps (note that for each of these tests, it is not necessary to perform the test case for each supported version of TLS):
+. Test 3 [conditional]: If the TOE supports session tickets according to RFC5077 (supported only by TLSv1.2), the evaluator shall carry out the following steps:
 [loweralpha]
-.. The evaluator shall permit a successful TLS handshake to occur in which a session ticket is exchanged with the non-TOE client. The evaluator shall then attempt to correctly reuse the previous session by sending the session ticket in the ClientHello. The evaluator shall confirm that the TOE responds with a ServerHello with an empty SessionTicket extension, NewSessionTicket, ChangeCipherSpec and Finished messages (as seen in figure 2 of RFC 5077).
+.. The evaluator shall permit a successful TLS handshake to occur in which a session ticket is exchanged with the non-TOE client. The evaluator shall then attempt to correctly reuse the previous session by sending the session ticket in the ClientHello. The evaluator shall confirm that the TOE responds with a ServerHello with an empty SessionTicket extension, NewSessionTicket, ChangeCipherSpec and Finished messages (as seen in figure 2 of RFC 5077). When the session is resumed, the evaluator shall verify on the TLS Client used for performing this test, that the TOE (TLS Server) has not advertised support for the early data extension.
 .. The evaluator shall permit a successful TLS handshake to occur in which a session ticket is exchanged with the non-TOE client. The evaluator will then modify the session ticket and send it as part of a new Client Hello message. The evaluator shall confirm that the TOE either (1) implicitly rejects the session ticket by performing a full handshake (as shown in figure 3 or 4 of RFC 5077), or (2) terminates the connection in some way that prevents the flow of application data.
+
+[arabic, start=569]
+. Test 4 [conditional]: If the TOE supports session resumption according to RFC8446 (supported only by TLSv1.3), the evaluator shall carry out the following steps: 
+[loweralpha]
+.. The evaluator shall permit a successful TLS handshake to occur in which a session ticket is exchanged with the non-TOE client.  The evaluator shall then attempt to correctly reuse the previous session by sending the pre-shared key in the ClientHello. The evaluator shall confirm that the TOE responds similarly to figure 3 of RFC 8446 after successfully reusing the pre-shared-key to resume the session. Specifically, the server must not send back a Certificate message if the session is correctly resumed. When the session is resumed, the evaluator shall verify on the TLS Client used for performing this test, that the TOE (TLS Server) has not advertised support for the early data extension.
+.. The evaluator shall permit a successful TLS handshake to occur in which a session ticket is exchanged with the non-TOE client.  The evaluator will then modify the pre-shared key and send it as part of a new Client Hello message.  The evaluator shall confirm that the TOE either (1) implicitly rejects the session ticket by performing a full handshake, or (2) terminates the connection in some way that prevents the flow of application data.
+.. The evaluator shall permit a successful TLS handshake to occur in which a session ticket is exchanged with the non-TOE client.  The evaluator will then force the non-TOE client to attempt to establish a new connection using the previous session ticket material as a pre-shared key, but set psk_key_exchange_modes with a value of psk_ke in the Client Hello message and omit the psk_ke_dhe.  The evaluator shall confirm that the TOE either (1) implicitly rejects the session ticket by performing a full handshake, or (2) terminates the connection in some way that prevents the flow of application data.
+
+*FCS_TLSS_EXT.1.6 [conditional]*
+
+[arabic, start=569]
+. If the TSF provides the ability of configuring the list of supported ciphersuites, the evaluator shall establish a TLS connection using one of the possible configurations of the list of supported ciphersuites. The evaluator shall then change the configuration and repeat the test. The evaluator shall verify that the behavior of the TOE has changed according to the modification of the list of ciphers. This test shall be repeated for all supported TLS versions. This test should be considered to be performed together with FCS_TLSS_EXT.1.1 Test 1. If the TSF does not provide the ability of configuring the list of supported ciphersuites, this test shall be omitted.
+
+*FCS_TLSS_EXT.1.7*
+
+[arabic, start=569]
+. According to RFC8446 section 4.2.10, a PSK is required to use the early data extension. As NDcPP only allows the use of PSK in conjunction with session resumption, a NDcPP conformant TOE which acts as TLS Server cannot use the early data extension if session resumption is not supported. For TOEs that do not support session resumption, execution of test FCS_TLSS_EXT.1.5 Test 1 is regarded as sufficient that the TOE does not support the early data extension. For TOEs that support session resumption, FCS_TLSS_EXT.1.5 Test 2a, 3a or 4a (depending on the supported TLS versions and the way session resumption is implemented) ensure that the TOE does not support the early data extension. 
 
 === Identification and Authentication (FIA)
 


### PR DESCRIPTION
3 Comments - 

1. The SD references FCS_TLSS_EXT.1.8 twice which no longer exists. I changed that to FCS_TLSS_EXT.1.7. 
2. In FCS_TLSS_EXT.1.2, it has Test X. Not sure what is X but I changed it to Test 1. 
3. The starts at xyz is all messed up. As we add more paragraph, there are repeating paragraph number. Nothing I can do now.