### PR TITLE
Tlswg jmh fcs tlss ext.3 update

### DIFF
--- a/ND Supporting Document 2_2.adoc
+++ b/ND Supporting Document 2_2.adoc
@@ -1604,6 +1604,34 @@ Some TOEs may set up the registration channel before the enablement step is carr
 
 (covered by FCS_TLSC_EXT.1.1 Test 1 and testing for FIA_X.509_EXT.).
 
+==== FCS_TLSC_EXT.3 Extended: TLS Client support for renegotiation (TLSv1.1/v1.2 only)
+
+===== TSS
+
+*FCS_TLSC_EXT.3.1*
+
+[arabic, start=299]
+. None.
+
+===== Guidance Documentation
+
+*FCS_TLSC_EXT.3.1*
+
+[arabic, start=300]
+. None
+
+===== Tests
+
+[arabic, start=301]
+. The evaluator shall perform the following tests.
+
+*FCS_TLSC_EXT.3.1*
+
+[arabic, start=302]
+. Test 1: The evaluator shall use a network packet analyzer/sniffer to capture the traffic between the two TLS endpoints. The evaluator shall verify that either the “renegotiation_info” field or the SCSV cipher suite is included in the ClientHello message during the initial handshake.
+. Test 2: The evaluator shall verify the Client’s handling of ServerHello messages received during the initial handshake that include the “renegotiation_info” extension. The evaluator shall modify the length portion of this field in the ServerHello message to be non-zero and verify that the client sends a failure and terminates the connection. The evaluator shall verify that a properly formatted field results in a successful TLS connection.
+. Test 3: The evaluator shall verify that ServerHello messages received during secure renegotiation contain the “renegotiation_info” extension. The evaluator shall modify either the “client_verify_data” or “server_verify_data” value and verify that the client terminates the connection.
+
 ==== FCS_TLSS_EXT.2 Extended: TLS Server support for mutual authentication
 
 ===== TSS
@@ -1663,6 +1691,34 @@ Some TOEs may set up the registration channel before the enablement step is carr
 [arabic, start=339]
 . The evaluator shall send a client certificate with an identifier that does not match an expected identifier and verify that the server denies the connection.
 
+==== FCS_TLSS_EXT.3 Extended: TLS Server support for renegotiation (TLSv1.1/v1.2 only)
+
+===== TSS
+
+*FCS_TLSS_EXT.3.1 and FCS_TLSS_EXT.3.2*
+
+[arabic, start=328]
+. None.
+
+===== Guidance Documentation
+
+*FCS_TLSS_EXT.3.1 and FCS_TLSS_EXT.3.2*
+
+[arabic, start=329]
+. None
+
+===== Tests
+
+[arabic, start=330]
+. The evaluator shall perform the following tests. The following tests require connection with a client that supports secure renegotiation and the "renegotiation_info" extension.
+
+*FCS_TLSS_EXT.3.1 and FCS_TLSS_EXT.3.2*
+
+[arabic, start=331]
+. Test 1: The evaluator shall use a network packet analyzer/sniffer to capture the traffic between the two TLS endpoints. The evaluator shall verify that the “renegotiation_info” field is included in the ServerHello message.
+. Test 2: The evaluator shall modify the length portion of the field in the ClientHello message in the initial handshake to be non-zero and verify that the server sends a failure and terminates the connection. The evaluator shall verify that a properly formatted field results in a successful TLS connection.
+. Test 3: The evaluator shall modify the "client_verify_data" or "server_verify_data" value in the ClientHello message received during secure renegotiation and verify that the server terminates the connection.
+
 == Evaluation Activities for Selection-Based Requirements
 
 === Security Audit (FAU)
@@ -1703,74 +1759,109 @@ Some TOEs may set up the registration channel before the enablement step is carr
 
 *FCS_DTLSC_EXT.1.1*
 
-[arabic, start=350]
+[arabic, start=344]
 . The evaluator shall check the description of the implementation of this protocol in the TSS to ensure that the ciphersuites supported are specified. The evaluator shall check the TSS to ensure that the ciphersuites specified include those listed for this component.
 
 *FCS_DTLSC_EXT.1.2*
 
-[arabic, start=351]
+[arabic, start=345]
 . The evaluator shall ensure that the TSS describes the client’s method of establishing all reference identifiers from the administrator/application-configured reference identifier, including which types of reference identifiers are supported (e.g. application-specific Subject Alternative Names) and whether IP addresses and wildcards are supported.
 . Note that where a DTLS channel is being used between components of a distributed TOE for FPT_ITT.1, the requirements to have the reference identifier established by the user are relaxed and the identifier may also be established through a “Gatekeeper” discovery process. The TSS should describe the discovery process and highlight how the reference identifier is supplied to the “joining” component. Where the secure channel is being used between components of a distributed TOE for FPT_ITT.1 and the ST author selected attributes from RFC 5280, the evaluator shall ensure the TSS describes which attribute type, or combination of attributes types, are used by the client to match the presented identifier with the configured identifier. The evaluator shall ensure the TSS presents an argument how the attribute type, or combination of attribute types, uniquely identify the remote TOE component; and the evaluator shall verify the attribute type, or combination of attribute types, is sufficient to support unique identification of the maximum supported number of TOE components.
 . If IP addresses are supported in the CN as reference identifiers, the evaluator shall ensure that the TSS describes the TOE’s conversion of the text representation of the IP address in the CN to a binary representation of the IP address in network byte order. The evaluator shall also ensure that the TSS describes whether canonical format (RFC 5952 for IPv6, RFC 3986 for IPv4) is enforced.
 
 *FCS_DTLSC_EXT.1.4*
 
-[arabic, start=354]
-. The evaluator shall verify that TSS describes the Supported Elliptic Curves/Supported Groups Extension and whether the required behaviour is performed by default or may be configured.
+[arabic, start=347]
+. The evaluator shall verify that TSS describes the Supported Groups Extension and whether the required behaviour is performed by default or may be configured.
+
+*FCS_DTLSC_EXT.1.5*
+
+[arabic, start=348]
+. The evaluator shall verify that TSS describes the signature_algorithm extension and whether the required behavior is performed by default or may be configured.
+
+[arabic, start=349]
+. If “not present the signature_algorithms extension” is selected, the evaluator shall verify that the TSS describes support for at least one RSA ciphersuite, RSA in FCS_COP.1/SigGen, and SHA-1 for FCS_COP.1/Hash.
+
+*FCS_DTLSC_EXT.1.6*
+
+[arabic, start=350]
+. The evaluator shall verify that TSS describes whether the list of supported ciphersuites can be configured or not.
+
+*FCS_DTLSC_EXT.1.8*
+
+[arabic, start=351]
+. The evaluator shall verify in the TSS that, for DTLS 1.3, the TOE shall not permit out-of-band provisioning of pre-shared keys (PSKs) in the evaluated configuration.
 
 ===== Guidance Documentation
 
 *FCS_DTLSC_EXT.1.1*
 
-[arabic, start=355]
+[arabic, start=352]
 . The evaluator shall also check the guidance documentation to ensure that it contains instructions on configuring the TOE so that DTLS conforms to the description in the TSS.
 
 *FCS_DTLSC_EXT.1.2*
 
-[arabic, start=356]
+[arabic, start=353]
 . The evaluator shall ensure that the operational guidance describes all supported identifiers, explicitly states whether the TOE supports the SAN extension or not and includes detailed instructions on how to configure the reference identifier(s) used to check the identity of peer(s). If the identifier scheme implemented by the TOE includes support for IP addresses, the evaluator shall ensure that the operational guidance provides a set of warnings and/or CA policy recommendations that would result in secure TOE use.
 . Where the secure channel is being used between components of a distributed TOE for FPT_ITT.1, the SFR selects attributes from RFC 5280, and FCO_CPC_EXT.1.2 selects “no channel”; the evaluator shall verify the guidance provides instructions for establishing unique reference identifiers based on RFC5280 attributes.
 
 *FCS_DTLSC_EXT.1.4*
 
-[arabic, start=358]
-. If the TSS indicates that the Supported Elliptic Curves/Supported Groups Extension must be configured to meet the requirement, the evaluator shall verify that AGD guidance includes configuration of the Supported Elliptic Curves/Supported Groups Extension.
+[arabic, start=354]
+. If the TSS indicates that the Supported Groups Extension must be configured to meet the requirement, the evaluator shall verify that AGD guidance includes configuration of the Supported Groups Extension.
+
+*FCS_DTLSC_EXT.1.5*
+
+[arabic, start=355]
+. If the TSS indicates that the signature_algorithm extension must be configured to meet the requirement, the evaluator shall verify that AGD guidance includes configuration of the signature_algorithm extension.
+
+*FCS_DTLSC_EXT.1.6*
+
+[arabic, start=356]
+. If the TSF provides the ability of configuring the list of supported ciphersuites, the evaluator shall verify that AGD guidance includes configuration of the list of supported ciphersuites.
+
+*FCS_DTLSC_EXT.1.8*
+
+[arabic, start=357]
+. The evaluator shall verify that any configuration necessary to meet the requirement must be contained in the AGD guidance.
 
 ===== Tests
 
-[arabic, start=359]
+[arabic, start=363]
 . For all tests in this chapter the DTLS server used for testing of the TOE shall be configured not to require mutual authentication.
 . For clarification: DTLS communication packets might be received in a different order than sent due to the use of the UDP protocol. All tests requiring a specific order of test steps ("before", "after") are therefore referring to the sequence numbering of DTLS packets.
 
 *FCS_DTLSC_EXT.1.1*
 
-[arabic, start=361]
+[arabic, start=360]
 . Test 1: The evaluator shall establish a DTLS connection using each of the ciphersuites specified by the requirement. This connection may be established as part of the establishment of a higher-level application protocol, e.g., as part of a syslog session. It is sufficient to observe the successful negotiation of a ciphersuite to satisfy the intent of the test; it is not necessary to examine the characteristics of the encrypted traffic in an attempt to discern the ciphersuite being used (for example, that the cryptographic algorithm is 128-bit AES and not 256-bit AES).
 . The goal of the following test is to verify that the TOE accepts only certificates with appropriate values in the extendedKeyUsage extension, and implicitly that the TOE correctly parses the extendedKeyUsage extension as part of X.509v3 server certificate validation.
 +
 Test 2: The evaluator shall attempt to establish the connection using a server with a server certificate that contains the Server Authentication purpose in the extendedKeyUsage extension and verify that a connection is established. The evaluator shall repeat this test using a different, but otherwise valid and trusted, certificate that lacks the Server Authentication purpose in the extendedKeyUsage extension and ensure that a connection is not established. Ideally, the two certificates should be similar in structure, the types of identifiers used, and the chain of trust.
-. Test 3: The evaluator shall send a server certificate in the DTLS connection that does not match the server-selected ciphersuite (for example, send an ECDSA certificate while using the TLS_RSA_WITH_AES_128_CBC_SHA ciphersuite). The evaluator shall verify that the TOE disconnects after receiving the server’s Certificate handshake message.
+. Test 3: [conditional]: Perform this test only if support of DTLS 1.0 or DTLS 1.2 is claimed (corresponding testing for DTLS 1.3 is covered by the tests for FCS_DTLSC_EXT.1.5). The evaluator shall send a server certificate in the DTLS connection that does not match the server-selected ciphersuite (for example, send an ECDSA certificate while using the TLS_RSA_WITH_AES_128_CBC_SHA ciphersuite). The evaluator shall verify that the TOE disconnects after receiving the server’s Certificate handshake message.
 . Test 4: The evaluator shall perform the following 'negative tests':
 [loweralpha]
-.. The evaluator shall configure the server to select the TLS_NULL_WITH_NULL_NULL ciphersuite and verify that the client denies the connection.
-.. Modify the server’s selected ciphersuite in the Server Hello handshake message to be a ciphersuite not presented in the Client Hello handshake message. The evaluator shall verify that the client rejects the connection after receiving the Server Hello.
-.. [conditional]: If the TOE presents the Supported Elliptic Curves/Supported Groups Extension the evaluator shall configure the server to perform an ECDHE or DHE key exchange in the DTLS connection using a non-supported curve/group (for example P-192) and shall verify that the TOE disconnects after receiving the server’s Key Exchange handshake message__.__
+.. [conditional]: Perform this test only if support of DTLS 1.0 or DTLS 1.2 is claimed. The evaluator shall configure the server to select the TLS_NULL_WITH_NULL_NULL ciphersuite and verify that the client denies the connection.
+.. Modify the server’s selected ciphersuite in the Server Hello handshake message to be a ciphersuite (compatible with the server-selected version of DTLS) not presented in the Client Hello handshake message. The evaluator shall verify that the client rejects the connection after receiving the Server Hello.
+.. The evaluator shall attempt to establish a DTLS connection using each of the DTLS versions (i.e. DTLS 1.3, DTLS 1.2, DTLS 1.0). The evaluator shall verify that the versions specified in FCS_DTLSC_EXT.1.1 are successfully established and all other versions are rejected by the client. The evaluator must ensure the ServerHello is valid for the DTLS version being negotiated. If the TOE includes the Supported Versions extension in its ClientHello, the evaluator shall also ensure the version(s) specified in the extension match the version(s) in FCS_DTLSC_EXT.1.1.
 
 [arabic, start=365]
-. Test 5: The evaluator performs the following modifications to the traffic:
+. Test 5: The evaluator performs the following modifications to the traffic (i.e. Man-in-the-middle modifications that result in invalid signatures and MACs):
 [loweralpha]
-.. Change the DTLS version selected by the server in the Server Hello to a non-supported DTLS version and verify that the client rejects the connection.
-.. [conditional]: If using DHE or ECDH, modify the signature block in the Server’s Key Exchange handshake message, and verify that the handshake is not finished successfully and no application data flows. This test does not apply to cipher suites using RSA key exchange. If a TOE only supports RSA key exchange in conjunction with DTLS, then this test shall be omitted.
-
+.. [conditional]: Perform this test only if support of DTLS 1.0 or DTLS 1.2 is claimed. If using DHE or ECDH ciphersuites, modify the signature block in the Server’s Key Exchange handshake message, and verify that the client denies the connection and no application data flows. The handshake shall be valid (e.g. the Finished message is calculated using the modified signature), with the exception of the invalid signature. This test does not apply to cipher suites using RSA key exchange. If a TOE only supports RSA key exchange in conjunction with DTLS then this test shall be omitted.
+.. [conditional]: Perform this test only if support of DTLS 1.3 is claimed. Modify the signature block in the Server’s Certificate Verify handshake message, and verify that the client denies the connection and no application data flows. The handshake shall be valid (e.g. the Finished message is calculated using the modified signature), with the exception of the invalid signature.
 . Test 6: The evaluator performs the following 'scrambled message tests':
 [loweralpha]
-.. Modify a byte in the Server Finished handshake message and verify that the handshake is not finished successfully and no application data flows.
-.. Send a garbled message from the Server after the Server has issued the ChangeCipherSpec message and verify that the handshake is not finished successfully and no application data flows.
-.. Modify at least one byte in the server’s nonce in the Server Hello handshake message and verify that the client rejects the Server Key Exchange handshake message (if using a DHE or ECDHE ciphersuite) or that the server denies the client’s Finished handshake message.
+.. Modify a byte in the Server Finished handshake message and verify that the handshake is not finished successfully and no application data flows. (_Note: This modification must be performed prior to the contents of the Finished message being encrypted.)_
+.. [conditional]: Perform this test only if support of DTLS 1.0 or DTLS 1.2 is claimed. Send a garbled message from the Server after the Server has issued the ChangeCipherSpec message and verify that the handshake is not finished successfully and no application data flows.
++
+_(Note: DTLS 1.3 provides for a dummy ChangeCipherSpec message to aid in middlebox compatibility if such an option is enabled in the specific implementation [see section D.4 in RFC 8446].  If DTLS 1.3 middlebox compatibility mode is enabled a ChangeCipherSpec message may appear in packet traces, but it does not influence the protocol. To be clear: for DTLS 1.3, this test does not need to be performed.)_
+.. [conditional] Perform this test only if support of DTLSv1.3 is claimed . Send a plaintext EncryptedExtensions message from the server and verify that the handshake is not finished successfully and no application data flows.  _(Note: Under DTLS 1.3, the EncryptedExtensions message is the first message to be encrypted with the handshake traffic secret.)_
+.. [conditional]: Perform this test only if support of DTLS 1.0 or DTLS 1.2 is claimed. Modify at least one byte in the server’s nonce in the Server Hello handshake message and verify that the client rejects the Server Key Exchange handshake message (if using a DHE or ECDHE ciphersuite) or that the server denies the client’s Finished handshake message.
 
 *FCS_DTLSC_EXT.1.2*
 
-[arabic, start=367]
+[arabic, start=366]
 . Note that tests 1-6 are only applicable to:
 [loweralpha]
 .. DTLS-based trusted channel communications according to FTP_ITC.1 and trusted path communications according to FTP_TRP.1
@@ -1812,7 +1903,7 @@ Remark: Some systems might require the presence of the SAN extension. In this ca
 
 *FCS_DTLSC_EXT.1.3*
 
-[arabic, start=371]
+[arabic, start=368]
 . The evaluator shall demonstrate that using an invalid certificate results in the function failing as follows:
 . Test 1: Using the administrative guidance, the evaluator shall load a CA certificate or certificates needed to validate the presented certificate used to authenticate an external entity and demonstrate that the function succeeds and a trusted channel can be established.
 . Test 2: The evaluator shall then change the presented certificate(s) so that validation fails and show that the certificate is not automatically accepted. The evaluator shall repeat this test to cover the selected types of failure defined in the SFR (i.e. the selected ones from failed matching of the reference identifier, failed validation of the certificate path, failed validation of the expiration date, failed determination of the revocation status). The evaluator performs the action indicated in the SFR selection observing the TSF resulting in the expected state for the trusted channel (e.g. trusted channel was established) covering the types of failure for which an override mechanism is defined.
@@ -1820,8 +1911,39 @@ Remark: Some systems might require the presence of the SAN extension. In this ca
 
 *FCS_DTLSC_EXT.1.4*
 
-[arabic, start=375]
-. Test 1 [conditional]: If the TOE presents the Supported Elliptic Curves/Supported Groups Extension, the evaluator shall configure the server to perform ECDHE or DHE (as applicable) key exchange using each of the TOE’s supported curves and/or groups. The evaluator shall verify that the TOE successfully connects to the server.
+[arabic, start=372]
+. Test 1 [conditional]: If “not present the Supported Groups Extension” is selected, the evaluator shall examine the Client Hello message and verify it does not contain the Supported Groups extension.
+. Test 2 [conditional]: If “present the Supported Groups Extension” is selected, the evaluator shall configure the server to perform ECDHE or DHE (as applicable) key exchange using each of the TOE’s supported groups. The evaluator shall verify that the connection succeeds. This test shall be repeated for each type of key exchange message/extension supported (i.e. Key Share extension for DTLS 1.3 and Server Key Exchange Message for DTLS 1.0 or DTLS 1.2).
+. Test 3 [conditional]: If secp groups are selected, the evaluator shall configure the server to perform an ECDHE key exchange in the TLS connection using a non-supported curve and shall verify that the connection fails and no application data flows. The non-supported curve shall be as similar to the selected curve(s) as possible (i.e. a non-selected curve when not all curves are selected or P-224). This test shall be repeated for each type of key exchange message/extension supported (i.e. Key Share extension for DTLS 1.3 and Server Key Exchange Message for DTLS 1.0 or DTLS 1.2).
+. Test 4 [conditional]: If ffdhe curves are selected, the evaluator shall configure the server to perform an DHE key exchange in the TLS connection using a non-supported group and shall verify that the connection fails and no application data flows. The non-supported group shall be as similar to the selected group(s) as possible (i.e. a non-selected group when not all groups are selected or undefined Codepoint 0x0105 (ffdhe8192 + 1)). This test shall be repeated for each type of key exchange message/extension supported (i.e. Key Share extension for DTLS 1.3 and Server Key Exchange Message for DTLSv1.0 or DTLS 1.2).
+
+*FCS_DTLSC_EXT.1.5*
+
+[arabic, start=376]
+. The evaluator shall perform the following tests:
+. Test 1 [conditional]: If “not present the signature_algorithms extension” is selected, the evaluator shall examine the Client Hello message and verify it does not contain the signature_algorihtms extension or the signature_algorithms_cert extension.
+. Test 2 [conditional]: The evaluator shall perform the following tests if “present the signature_algorithms extension” is selected:
+[arabic]
+[loweralpha]
+... The evaluator shall examine the Client Hello message and verify it contains the signature_algorihtms extension and the SignatureSchemes match the SignatureSchemes specified in the requirement.
+... The evaluator shall establish a DTLS connection using each of the SignatureSchemes specified by the requirement and observes the session is successfully completed. The evaluator shall ensure the test server sends Certificate and Certificate Verify messages that are consistent with the SignatureScheme being tested.
+. Test 3 [conditional]: The evaluator shall perform the following tests if “present the signature_algorithms_cert extension” is selected:
+[arabic]
+[loweralpha]
+... The evaluator shall examine the Client Hello message and verify it contains the signature_algorihtms_cert extension and the SignatureSchemes match the SignatureSchemes specified in the requirement.
+... The evaluator shall establish a DTLS connection using a certificate chain using each of the SignatureSchemes specified by the requirement. The evaluator shall ensure the signatures used in the certificate chain are consistent with the SignatureScheme being tested.
++
+Remark: The server must ensure the DTLS handshake is valid (e.g. certificate key, Certificate Verify message, message formatting, hashes, and signatures), except for the certificate chain using a SignatureScheme not proposed by the client. The selected legacy SignatureScheme shall be as similar to one of the supported SignatureSchemes as possible. For example: 1) ecdsa_sha1 shall not be used if the TOE only supports RSA signatures, 2) ecdsa_sha1 must use a supported ECDSA curve or P-256 if only EdDSA curves are supported.
+
+*FCS_DTLSC_EXT.1.6 [conditional]*
+
+[arabic, start=380]
+. If the TSF provides the ability of configuring the list of supported ciphersuites, the evaluator shall establish a DTLS connection using one of the possible configurations of the list of supported ciphersuites. The evaluator shall then change the configuration and repeat the test. The evaluator shall verify that the behavior of the TOE has changed according to the modification of the list of ciphers. This test shall be repeated for all supported DTLS versions. This test should be considered to be performed together with FCS_DTLSC_EXT.1.1 Test 1. If the TSF does not provide the ability of configuring the list of supported ciphersuites, this test shall be omitted.
+
+*FCS_DTLSC_EXT.1.7*
+
+[arabic, start=381]
+. The evaluator shall establish a DTLS connection with a server and observe that the early data extension and the post-handshake client authentication extension according to RFC(tbd- current draft for DTLS 1.3 is V38), section 5.7.3 are not advertised in the Client Hello Message. This test shall be executed for all DTLS versions supported by the TOE.
 
 ==== FCS_DTLSS_EXT.1 Extended: DTLS Server Protocol without mutual authentication
 

--- a/ND Supporting Document 2_2.adoc
+++ b/ND Supporting Document 2_2.adoc
@@ -2648,7 +2648,7 @@ Remark: Some systems might require the presence of the SAN extension. In this ca
 [arabic, start=550]
 . Test 1 [conditional]: If the TOE presents the Supported Elliptic Curves/Supported Groups Extension, _the evaluator shall configure the server to perform ECDHE or DHE (as applicable) key exchange using each of the TOE’s supported curves and/or groups. The evaluator shall verify that the TOE successfully connects to the server.
 
-==== FCS_TLSS_EXT.1 Extended: TLS Server Protocol without mutual authentication
+==== FCS_TLSS_EXT.1 Extended: TLS Server Protocol
 
 ===== TSS
 
@@ -2660,33 +2660,60 @@ Remark: Some systems might require the presence of the SAN extension. In this ca
 *FCS_TLSS_EXT.1.2*
 
 [arabic, start=552]
-. The evaluator shall verify that the TSS contains a description of how the TOE technically prevents the use of old SSL and TLS versions.
+. The evaluator shall verify that the TSS contains a description of how the TOE technically prevents the use of unsupported and undefined SSL and TLS versions.
 
 *FCS_TLSS_EXT.1.3*
 
 [arabic, start=553]
-. If using ECDHE or DHE ciphers, the evaluator shall verify that the TSS describes the key agreement parameters of the server Key Exchange message.
+. If using ECDHE or DHE ciphers, the evaluator shall verify that the TSS describes the algorithms and key sizes the TSF supports for authenticating itself to TLS clients. The evaluator shall ensure these algorithms are consistent with the selected ciphersuites.
 
 *FCS_TLSS_EXT.1.4*
 
 [arabic, start=554]
-. The evaluator shall verify that the TSS describes if session resumption based on session IDs is supported (RFC 4346 and/or RFC 5246) and/or if session resumption based on session tickets is supported (RFC 5077).
+. The evaluator shall verify that the TSS describes the key exchange parameters of the server Key Exchange message. The evaluator shall ensure these algorithms are consistent with the selected ciphersuites.
+
+*FCS_TLSS_EXT.1.5*
+
+[arabic, start=555]
+. The evaluator shall verify that the TSS describes if session resumption based on session IDs is supported (RFC 4346 and/or RFC 5246), if session resumption based on session tickets is supported (RFC 5077) and/or if session resumption according to RFC8446 is supported.
+
 . If session tickets are supported, the evaluator shall verify that the TSS describes that the session tickets are encrypted using symmetric algorithms consistent with FCS_COP.1/DataEncryption. The evaluator shall verify that the TSS identifies the key lengths and algorithms used to protect session tickets.
+
 . If session tickets are supported, the evaluator shall verify that the TSS describes that session tickets adhere to the structural format provided in section 4 of RFC 5077 and if not, a justification shall be given of the actual session ticket format.
+
+*FCS_TLSS_EXT.1.6*
+
+[arabic, start=556]
+. The evaluator shall verify that TSS describes whether the list of supported ciphersuites can be configured or not.
+
+*FCS_TLSS_EXT.1.7*
+
+[arabic, start=557]
+. The evaluator shall verify in the TSS that, for TLS 1.3, the TOE shall not permit out-of-band provisioning of pre-shared keys (PSKs) in the evaluated configuration.
 
 ===== Guidance Documentation
 
 *FCS_TLSS_EXT.1.1*
 
 [arabic, start=557]
-. The evaluator shall check the guidance documentation to ensure that it contains instructions on configuring the TOE so that TLS conforms to the description in the TSS (for instance, the set of ciphersuites advertised by the TOE may have to be restricted to meet the requirements).
+. The evaluator shall check the guidance documentation to ensure that it contains instructions on configuring the TOE so that TLS conforms to the description in the TSS (for instance, the set of ciphersuites advertised by the TOE or TLS version supported by the TOE may have to be restricted to meet the requirements).
 
-*FCS_TLSS_EXT.1.2*
+*FCS_TLSS_EXT.1.3*
 
 [arabic, start=558]
 . The evaluator shall verify that any configuration necessary to meet the requirement must be contained in the AGD guidance.
 
-*FCS_TLSS_EXT.1.3*
+*FCS_TLSS_EXT.1.4*
+
+[arabic, start=558]
+. The evaluator shall verify that any configuration necessary to meet the requirement must be contained in the AGD guidance.
+
+*FCS_TLSS_EXT.1.6*
+
+[arabic, start=559]
+. If the TSF provides the ability of configuring the list of supported ciphersuites, the evaluator shall verify that AGD guidance includes configuration of the list of supported ciphersuites.
+
+*FCS_TLSS_EXT.1.7*
 
 [arabic, start=559]
 . The evaluator shall verify that any configuration necessary to meet the requirement must be contained in the AGD guidance.
@@ -2697,43 +2724,56 @@ Remark: Some systems might require the presence of the SAN extension. In this ca
 
 [arabic, start=560]
 . Test 1: The evaluator shall establish a TLS connection using each of the ciphersuites specified by the requirement. This connection may be established as part of the establishment of a higher-level protocol, e.g., as part of an HTTPS session. It is sufficient to observe the successful negotiation of a ciphersuite to satisfy the intent of the test; it is not necessary to examine the characteristics of the encrypted traffic to discern the ciphersuite being used (for example, that the cryptographic algorithm is 128-bit AES and not 256-bit AES).
-. Test 2: The evaluator shall send a Client Hello to the server with a list of ciphersuites that does not contain any of the ciphersuites in the server’s ST and verify that the server denies the connection. Additionally, the evaluator shall send a Client Hello to the server containing only the TLS_NULL_WITH_NULL_NULL ciphersuite and verify that the server denies the connection.
+. Test 2: The evaluator shall perform the following tests:
+.. The evaluator shall send a Client Hello to the server with a list of ciphersuites that does not contain any of the ciphersuites in the server’s ST and verify that the server denies the connection. 
+.. [conditional]: Perform this test only if support of TLSv1.1 or TLSv1.2 is claimed. The evaluator shall send a Client Hello to the server containing only the TLS_NULL_WITH_NULL_NULL ciphersuite and verify that the server denies the connection.
 . Test 3: The evaluator shall perform the following modifications to the traffic:
 [loweralpha]
-.. Modify a byte in the Client Finished handshake message, and verify that the server rejects the connection and does not send any application data.
+.. [conditional]: Perform this test only if support of TLSv1.1 or TLSv1.2 is claimed. Modify a byte in the Client Finished handshake message, and verify that the server rejects the connection and does not send any application data.
 .. (Test Intent: The intent of this test is to ensure that the server's TLS implementation immediately makes use of the key exchange and authentication algorithms to: a) Correctly encrypt (D)TLS Finished message and b) Encrypt every (D)TLS message after session keys are negotiated.)
 +
 
-The evaluator shall use one of the claimed ciphersuites to complete a successful handshake and observe transmission of properly encrypted application data. The evaluator shall verify that no Alert with alert level Fatal (2) messages were sent.
+[conditional]: Perform this test only if support of TLSv1.1 or TLSv1.2 is claimed. The evaluator shall use one of the claimed ciphersuites to complete a successful handshake and observe transmission of properly encrypted application data. The evaluator shall verify that no Alert with alert level Fatal (2) messages were sent.
 +
 
 The evaluator shall verify that the Finished message (Content type hexadecimal 16 and handshake message type hexadecimal 14) is sent immediately after the server's ChangeCipherSpec (Content type hexadecimal 14) message. The evaluator shall examine the Finished message (encrypted example in hexadecimal of a TLS record containing a Finished message, 16 03 03 00 40 11 22 33 44 55...) and confirm that it does not contain unencrypted data (unencrypted example in hexadecimal of a TLS record containing a Finished message, 16 03 03 00 40 14 00 00 0c...), by verifying that the first byte of the encrypted Finished message does not equal hexadecimal 14 for at least one of three test messages. There is a chance that an encrypted Finished message contains a hexadecimal value of '14' at the position where a plaintext Finished message would contain the message type code '14'. If the observed Finished message contains a hexadecimal value of '14' at the position where the plaintext Finished message would contain the message type code, the test shall be repeated three times in total. In case the value of '14' can be observed in all three tests it can be assumed that the Finished message has indeed been sent in plaintext and the test has to be regarded as 'failed'. Otherwise it has to be assumed that the observation of the value '14' has been due to chance and that the Finished message has indeed been sent encrypted. In that latter case the test shall be regarded as 'passed'.
 
+.. [conditional]: Perform this test only if support of TLSv1.3 is claimed. The evaluator shall use a client to send a Client Hello message containing a single curve in the Supported Groups extension. The curve that is selected to be presented in this extension should not be supported by the TOE. The evaluator shall verify that the TOE disconnects after receiving the Client Hello message.
+
+.. [conditional]: Perform this test only if support of TLSv1.3 is claimed. The evaluator shall use a client to send a Client Hello message containing a multiple curves in the Supported Groups extension. These curves should be chosen such that only one of these curves is supported by the TOE. The evaluator shall verify that the TOE responds with a Hello Retry Request message selecting the supported curve. This shall be reflected in the Key Share extension of the Hello Retry Request message.
+
 *FCS_TLSS_EXT.1.2*
 
 [arabic, start=563]
-. The evaluator shall send a Client Hello requesting a connection for all mandatory and selected protocol versions in the SFR (e.g. by enumeration of protocol versions in a test client) and verify that the server denies the connection for each attempt.
+. Test 1: The evaluator shall attempt to establish a TLS/SSL connection using each of the TLS/SSL versions (i.e., TLS1.3, TLS1.2, TLS1.1, TLS1.0, SSL3.0, SSL2.0). The client shall be configured so it only supports the version being tested. The evaluator shall verify that the versions specified in FCS_TLSS_EXT.1.1 are successfully established and all other versions not successfully established. If the TOE attempts to downgrade the version, it is acceptable for the test client to terminate the connection; however, the version selected by the TOE shall always be a version specified in FCS_TLSS_EXT.1.1.
 
-*FCS_TLSS_EXT.1.3*
+*FCS_TLSS_EXT.1.3 and FCS_TLSS_EXT.1.4*
 
 [arabic, start=564]
-. Test 1: [conditional] If ECDHE ciphersuites are supported:
+. Test 1: [conditional] If ECDHE ciphersuites/group are supported:
 [loweralpha]
-.. The evaluator shall repeat this test for each supported elliptic curve. The evaluator shall attempt a connection using a supported ECDHE ciphersuite and a single supported elliptic curve specified in the Elliptic Curves Extension. The Evaluator shall verify (though a packet capture or instrumented client) that the TOE selects the same curve in the Server Key Exchange message and successfully establishes the connection.
-.. The evaluator shall attempt a connection using a supported ECDHE ciphersuite and a single unsupported elliptic curve (e.g. secp192r1 (0x13)) specified in RFC4492, chap. 5.1.1. The evaluator shall verify that the TOE does not send a Server Hello message and the connection is not successfully established.
-. Test 2: [conditional] If DHE ciphersuites are supported, the evaluator shall repeat the following test for each supported parameter size. If any configuration is necessary, the evaluator shall configure the TOE to use a supported Diffie-Hellman parameter size. The evaluator shall attempt a connection using a supported DHE ciphersuite. The evaluator shall verify (through a packet capture or instrumented client) that the TOE sends a Server Key Exchange Message where p Length is consistent with the message are the ones configured Diffie-Hellman parameter size(s).
+.. The evaluator shall repeat this test for each supported elliptic curve. The evaluator shall attempt a connection using a supported ECDHE ciphersuite (TLSv1.1/v1.2) or group (TLSv1.3) and a single supported elliptic curve specified in the supported groups extension. The Evaluator shall verify (through a packet capture or instrumented client) that the TOE selects the same curve in the Server Key Exchange (TLSv1.1/v1.2) or Server Hello (key_share, for TLSv1.3) message and successfully establishes the connection.
+.. The evaluator shall attempt a connection using a supported ECDHE ciphersuite (TLSv1.1/1.2) or group (TLSv1.3) and a single unsupported elliptic curve (e.g. secp192r1 (0x13)) specified in RFC4492, chap. 5.1.1. The evaluator shall verify that the TOE does not send a Server Hello message and the connection is not successfully established.
+. Test 2: [conditional] If DHE ciphersuites are supported, the evaluator shall repeat the following test for each supported parameter size. If any configuration is necessary, the evaluator shall configure the TOE to use a supported Diffie-Hellman parameter size. The evaluator shall attempt a connection using a supported DHE ciphersuite. 
++
+
+For TLS1.1 and TLS.1.2, the evaluator shall verify (through a packet capture or instrumented client) that the TOE sends a Server Key Exchange Message where p Length is consistent with the message are the ones configured Diffie-Hellman parameter size(s).
++
+
+For TLS1.3, the evaluator shall verify (through a packet capture or instrumented client) that the TOE sends a Server Key Share Extension Message where the KeyShareServerHello structure contains a KeyShareEntry structure with an opaque key_exchange value whose Length is consistent with the configured Diffie-Hellman parameter size(s). 
+
 . Test 3: [conditional] If RSA key establishment ciphersuites are supported, the evaluator shall repeat this test for each RSA key establishment key size. If any configuration is necessary, the evaluator shall configure the TOE to perform RSA key establishment using a supported key size (e.g. by loading a certificate with the appropriate key size). The evaluator shall attempt a connection using a supported RSA key establishment ciphersuite. The evaluator shall verify (through a packet capture or instrumented client) that the TOE sends a certificate whose modulus is consistent with the configured RSA key size.
 
-*FCS_TLSS_EXT.1.4*
+*FCS_TLSS_EXT.1.5*
 
 _Test Objective: To demonstrate that the TOE will not resume a session for which the client failed to complete the handshake (independent of TOE support for session resumption)._
 
 [arabic, start=567]
-. Test 1 [conditional]: If the TOE does not support session resumption based on session IDs according to RFC4346 (TLS1.1) or RFC5246 (TLS1.2) or session tickets according to RFC5077, the evaluator shall perform the following test:
+. Test 1 [conditional]: If the TOE does not support session resumption based on session IDs according to RFC4346 (TLS1.1) or RFC5246 (TLS1.2) or session tickets according to RFC5077 (TLS1.2) or session resumption according to RFC8446 (TLS1.3), the evaluator shall perform the following test:
 [loweralpha]
-.. The client sends a Client Hello with a zero-length session identifier and with a SessionTicket extension containing a zero-length ticket.
+.. For all supported TLS versions the client shall send a Client Hello with a zero-length session identifier and with a SessionTicket extension containing a zero-length ticket. A non-zero length session identifier for TLSv1.3 would result in testing compatibility mode which is not the objective of this test. For TLSv1.3, the evaluator shall ensure that a 'psk_key_exchange_modes' extension is included in the Client Hello.
 .. The client verifies the server does not send a NewSessionTicket handshake message (at any point in the handshake).
-.. The client verifies the Server Hello message contains a zero-length session identifier or passes the following steps:
+.. The client verifies the Server Hello message contains a zero-length session identifier. For TLSv1.1 and TLSv1.2 the client could alternatively pass the following steps (not applicable for TLSv1.3):
 +
 Note: The following steps are only performed if the ServerHello message contains a non-zero length SessionID.
 [loweralpha, start=4]
@@ -2744,14 +2784,31 @@ Note: The following steps are only performed if the ServerHello message contains
 [arabic, start=568]
 . Test 2 [conditional]: If the TOE supports session resumption using session IDs according to RFC4346 (TLS1.1) or RFC5246 (TLS1.2), the evaluator shall carry out the following steps (note that for each of these tests, it is not necessary to perform the test case for each supported version of TLS):
 [loweralpha]
-.. The evaluator shall conduct a successful handshake and capture the TOE-generated session ID in the Server Hello message. The evaluator shall then initiate a new TLS connection and send the previously captured session ID to show that the TOE resumed the previous session by responding with ServerHello containing the same SessionID immediately followed by ChangeCipherSpec and Finished messages (as shown in Figure 2 of RFC 4346 or RFC 5246).
+.. The evaluator shall conduct a successful handshake and capture the TOE-generated session ID in the Server Hello message. The evaluator shall then initiate a new TLS connection and send the previously captured session ID to show that the TOE resumed the previous session by responding with ServerHello containing the same SessionID immediately followed by ChangeCipherSpec and Finished messages (as shown in Figure 2 of RFC 4346 or RFC 5246). When the session is resumed, the evaluator shall verify on the TLS Client used for performing this test, that the TOE (TLS Server) has not advertised support for the early data extension. 
 .. The evaluator shall initiate a handshake and capture the TOE-generated session ID in the Server Hello message. The evaluator shall then, within the same handshake, generate or force an unencrypted fatal Alert message immediately before the client would otherwise send its ChangeCipherSpec message thereby disrupting the handshake. The evaluator shall then initiate a new Client Hello using the previously captured session ID, and verify that the server (1) implicitly rejects the session ID by sending a ServerHello containing a different SessionID and performing a full handshake (as shown in figure 1 of RFC 4346 or RFC 5246), or (2) terminates the connection in some way that prevents the flow of application data.
 
 [arabic, start=569]
-. Test 3 [conditional]: If the TOE supports session tickets according to RFC5077, the evaluator shall carry out the following steps (note that for each of these tests, it is not necessary to perform the test case for each supported version of TLS):
+. Test 3 [conditional]: If the TOE supports session tickets according to RFC5077 (supported only by TLSv1.2), the evaluator shall carry out the following steps:
 [loweralpha]
-.. The evaluator shall permit a successful TLS handshake to occur in which a session ticket is exchanged with the non-TOE client. The evaluator shall then attempt to correctly reuse the previous session by sending the session ticket in the ClientHello. The evaluator shall confirm that the TOE responds with a ServerHello with an empty SessionTicket extension, NewSessionTicket, ChangeCipherSpec and Finished messages (as seen in figure 2 of RFC 5077).
+.. The evaluator shall permit a successful TLS handshake to occur in which a session ticket is exchanged with the non-TOE client. The evaluator shall then attempt to correctly reuse the previous session by sending the session ticket in the ClientHello. The evaluator shall confirm that the TOE responds with a ServerHello with an empty SessionTicket extension, NewSessionTicket, ChangeCipherSpec and Finished messages (as seen in figure 2 of RFC 5077). When the session is resumed, the evaluator shall verify on the TLS Client used for performing this test, that the TOE (TLS Server) has not advertised support for the early data extension.
 .. The evaluator shall permit a successful TLS handshake to occur in which a session ticket is exchanged with the non-TOE client. The evaluator will then modify the session ticket and send it as part of a new Client Hello message. The evaluator shall confirm that the TOE either (1) implicitly rejects the session ticket by performing a full handshake (as shown in figure 3 or 4 of RFC 5077), or (2) terminates the connection in some way that prevents the flow of application data.
+
+[arabic, start=569]
+. Test 4 [conditional]: If the TOE supports session resumption according to RFC8446 (supported only by TLSv1.3), the evaluator shall carry out the following steps: 
+[loweralpha]
+.. The evaluator shall permit a successful TLS handshake to occur in which a session ticket is exchanged with the non-TOE client.  The evaluator shall then attempt to correctly reuse the previous session by sending the pre-shared key in the ClientHello. The evaluator shall confirm that the TOE responds similarly to figure 3 of RFC 8446 after successfully reusing the pre-shared-key to resume the session. Specifically, the server must not send back a Certificate message if the session is correctly resumed. When the session is resumed, the evaluator shall verify on the TLS Client used for performing this test, that the TOE (TLS Server) has not advertised support for the early data extension.
+.. The evaluator shall permit a successful TLS handshake to occur in which a session ticket is exchanged with the non-TOE client.  The evaluator will then modify the pre-shared key and send it as part of a new Client Hello message.  The evaluator shall confirm that the TOE either (1) implicitly rejects the session ticket by performing a full handshake, or (2) terminates the connection in some way that prevents the flow of application data.
+.. The evaluator shall permit a successful TLS handshake to occur in which a session ticket is exchanged with the non-TOE client.  The evaluator will then force the non-TOE client to attempt to establish a new connection using the previous session ticket material as a pre-shared key, but set psk_key_exchange_modes with a value of psk_ke in the Client Hello message and omit the psk_ke_dhe.  The evaluator shall confirm that the TOE either (1) implicitly rejects the session ticket by performing a full handshake, or (2) terminates the connection in some way that prevents the flow of application data.
+
+*FCS_TLSS_EXT.1.6 [conditional]*
+
+[arabic, start=569]
+. If the TSF provides the ability of configuring the list of supported ciphersuites, the evaluator shall establish a TLS connection using one of the possible configurations of the list of supported ciphersuites. The evaluator shall then change the configuration and repeat the test. The evaluator shall verify that the behavior of the TOE has changed according to the modification of the list of ciphers. This test shall be repeated for all supported TLS versions. This test should be considered to be performed together with FCS_TLSS_EXT.1.1 Test 1. If the TSF does not provide the ability of configuring the list of supported ciphersuites, this test shall be omitted.
+
+*FCS_TLSS_EXT.1.7*
+
+[arabic, start=569]
+. According to RFC8446 section 4.2.10, a PSK is required to use the early data extension. As NDcPP only allows the use of PSK in conjunction with session resumption, a NDcPP conformant TOE which acts as TLS Server cannot use the early data extension if session resumption is not supported. For TOEs that do not support session resumption, execution of test FCS_TLSS_EXT.1.5 Test 1 is regarded as sufficient that the TOE does not support the early data extension. For TOEs that support session resumption, FCS_TLSS_EXT.1.5 Test 2a, 3a or 4a (depending on the supported TLS versions and the way session resumption is implemented) ensure that the TOE does not support the early data extension. 
 
 === Identification and Authentication (FIA)
 

--- a/ND Supporting Document 2_2.adoc
+++ b/ND Supporting Document 2_2.adoc
@@ -1528,12 +1528,17 @@ Some TOEs may set up the registration channel before the enablement step is carr
 
 [arabic, start=296]
 . The evaluator shall ensure that the TSS description required per FIA_X509_EXT.2.1 includes the use of client-side certificates for DTLS mutual authentication.
-. The evaluator shall verify the TSS describes how the TSF uses certificates to authenticate the DTLS client. The evaluator shall verify the TSS describes whether the TSF supports any fallback authentication functions (e.g. username/password, challenge response) the TSF uses to authenticate DTLS clients that do not present a certificate. If fallback authentication functions are supported, the evaluator shall verify the TSS describes whether the fallback authentication functions can be disabled.*
+. The evaluator shall verify the TSS describes how the TSF uses certificates to authenticate the DTLS client and how the TOE reacts in case either the client does not send a client certificate or the verification of the client certificate fails. The evaluator shall verify the TSS describes whether the TSF supports any fallback authentication functions (e.g. username/password, challenge response) the TSF uses to authenticate DTLS clients that do not present a certificate. If fallback authentication functions are supported, the evaluator shall verify the TSS describes whether the fallback authentication functions can be disabled.
 
 *FCS_DTLSS_EXT.2.3*
 
 [arabic, start=298]
 . The evaluator shall verify that the TSS describes which types of identifiers are supported for during client authentication (e.g. Fully Qualified Domain Name (FQDN)). If FQDNs are supported, the evaluator shall verify that the TSS describes that corresponding identifiers are matched according to RFC6125. For all other types of identifiers, the evaluator shall verify that the TSS describes how these identifiers are parsed from the certificate, what the expected identifiers are and how the parsed identifiers from the certificate are matched against the expected identifiers.
+
+*FCS_DTLSS_EXT.2.4*
+
+[arabic, start=298]
+. The evaluator shall verify that TSS describes the signature_algorithm extension and whether the required behavior is performed by default or may be configured.
 
 ===== Guidance Documentation
 
@@ -1548,6 +1553,11 @@ Some TOEs may set up the registration channel before the enablement step is carr
 [arabic, start=301]
 . The evaluator shall ensure that the AGD guidance describes the configuration of expected identifier(s) for X.509 certificate-based authentication of DTLS clients. The evaluator ensures this description includes all types of identifiers described in the TSS and, if claimed, configuration of the TOE to use a directory server.
 
+*FCS_DTLSS_EXT.2.4*
+
+[arabic, start=301]
+. If the TSS indicates that the signature_algorithm extension must be configured to meet the requirement, the evaluator shall verify that AGD guidance includes configuration of the signature_algorithm extension.
+
 ===== Tests
 
 [arabic, start=302]
@@ -1557,27 +1567,45 @@ Some TOEs may set up the registration channel before the enablement step is carr
 *FCS_DTLSS_EXT.2.1 and FCS_DTLSS_EXT.2.2*
 
 [arabic, start=304]
-. Test 1a [conditional]: If the TOE requires or can be configured to require a client certificate, the evaluator shall configure the TOE to require a client certificate and send a Certificate Request to the client. The evaluator shall attempt a connection while sending a certificate_list structure with a length of zero in the Client Certificate message. The evaluator shall verify that the handshake is not finished successfully and no application data flows.
-. Test 1b [conditional]: If the TOE supports fallback authentication functions and these functions cannot be disabled, the evaluator shall configure the fallback authentication functions on the TOE and configure the TOE to send a Certificate Request to the client. The evaluator shall attempt a connection while sending a certificate_list structure with a length of zero in the Client Certificate message. The evaluator shall verify the TOE authenticates the connection using the fallback authentication functions as described in the TSS.
+. Test 1a [conditional]: If the 'hard fail' option has been selected in FCS_DTLSS_EXT.2.1, the evaluator shall configure the TOE to require a client certificate and send a Certificate Request to the client. The evaluator shall attempt a connection while sending a certificate_list structure with a length of zero in the Client Certificate message. The evaluator shall verify that the handshake is not finished successfully and no application data flows.
+. Test 1b [conditional]: If the 'soft fail' option has been selected in FCS_TLSS_EXT.2.1, the evaluator shall configure the TOE to require a client certificate and configure the TOE to send a Certificate Request to the client. The evaluator shall attempt a connection while sending a certificate_list structure with a length of zero in the Client Certificate message. The evaluator verifies the client remains unauthenticated (e.g. requires application layer authentication tested according to the related SFRs for this application layer authentication) or is restricted to unauthenticated operations.
 . Note: Testing the validity of the client certificate is performed as part of X.509 testing.
-. Test 2 [conditional]: If DTLS 1.2 is claimed for the TOE, the evaluator shall configure the server to send a certificate request to the client without the supported_signature_algorithm used by the client's certificate. The evaluator shall attempt a connection using the client certificate and verify that the connection is denied.
-. Test 3: The aim of this test is to check the response of the server when it receives a client identity certificate that is signed by an impostor CA (either Root CA or intermediate CA). To carry out this test the evaluator shall configure the client to send a client identity certificate with an issuer field that identifies a CA recognised by the TOE as a trusted CA, but where the key used for the signature on the client certificate does not correspond to the CA certificate trusted by the TOE (meaning that the client certificate is invalid because its certification path does not terminate in the claimed CA certificate). The evaluator shall verify that the attempted connection is denied.
-. Test 4: The evaluator shall configure the client to send a certificate with the Client Authentication purpose in the extendedKeyUsage field and verify that the server accepts the attempted connection. The evaluator shall repeat this test without the Client Authentication purpose and shall verify that the server denies the connection. Ideally, the two certificates should be identical except for the Client Authentication purpose.
-. Test 5: The evaluator shall perform the following modifications to the traffic:
+. Test 2: The aim of this test is to check the response of the server when it receives a client identity certificate that is signed by an impostor CA (either Root CA or intermediate CA). To carry out this test the evaluator shall configure the client to send a client identity certificate with an issuer field that identifies a CA recognised by the TOE as a trusted CA, but where the key used for the signature on the client certificate does not correspond to the CA certificate trusted by the TOE (meaning that the client certificate is invalid because its certification path does not terminate in the claimed CA certificate). The evaluator shall verify that the attempted connection is denied.
+. Test 3: The evaluator shall configure the client to send a certificate with the Client Authentication purpose in the extendedKeyUsage field and verify that the server accepts the attempted connection. The evaluator shall repeat this test without the Client Authentication purpose and shall verify that the server denies the connection. Ideally, the two certificates should be identical except for the Client Authentication purpose.
+. Test 4: The evaluator shall perform the following modifications to the traffic:
 [loweralpha]
-.. Configure the server to require mutual authentication and then connect to the server with a client configured to send a client certificate that is signed by a Certificate Authority trusted by the TOE. The evaluator shall verify that the server accepts the connection.
-.. Configure the server to require mutual authentication and then modify a byte in the signature block of the client’s Certificate Verify handshake message (see RFC5246 Sec 7.4.8). The evaluator shall verify that the server rejects the connection.
+.. [conditional]: Perform this test only if support of DTLS 1.0 or DTLS 1.2 is claimed. Configure the server to require mutual authentication and then connect to the server with a client configured to send a client certificate that is signed by a Certificate Authority trusted by the TOE. The evaluator shall verify that the server accepts the connection.
+.. [conditional]: Perform this test only if support of DTLS 1.0 or DTLS 1.2 is claimed. Configure the server to require mutual authentication and then modify a byte in the signature block of the client’s Certificate Verify handshake message (see RFC5246 Sec 7.4.8). The evaluator shall verify that the server rejects the connection.
 [arabic, start=311]
 . Note: Testing the validity of the client certificate is performed as part of X.509 testing.
-. The evaluator shall demonstrate that using an invalid certificate results in the function failing as follows:
-. Test 6: Using the administrative guidance, the evaluator shall load a CA certificate or certificates needed to validate the presented certificate used to authenticate an external entity and demonstrate that the function succeeds, and a trusted channel can be established.
-. Test 7: The evaluator shall then change the presented certificate(s) so that validation fails and show that the certificate is not automatically accepted. The evaluator shall repeat this test to cover the selected types of failure defined in the SFR (i.e. the selected ones from failed matching of the reference identifier, failed validation of the certificate path, failed validation of the expiration date, failed determination of the revocation status). The evaluator performs the action indicated in the SFR selection observing the TSF resulting in the expected state for the trusted channel (e.g. trusted channel was established) covering the types of failure for which an override mechanism is defined.
-. Test 8 [conditional]: The purpose of this test is to verify that only selected certificate validation failures could be administratively overridden. If any override mechanism is defined for failed certificate validation, the evaluator shall configure a new presented certificate that does not contain a valid entry in one of the mandatory fields or parameters (e.g. inappropriate value in extendedKeyUsage field) but is otherwise valid and signed by a trusted CA. The evaluator shall confirm that the certificate validation fails (i.e. certificate is rejected), and there is no administrative override available to accept such certificate.
+. Test 5 [conditional]: The purpose of this test is to verify that only selected certificate validation failures could be administratively overridden. If any override mechanism is defined for failed certificate validation, the evaluator shall configure a new presented certificate that does not contain a valid entry in one of the mandatory fields or parameters (e.g. inappropriate value in extendedKeyUsage field) but is otherwise valid and signed by a trusted CA. The evaluator shall confirm that the certificate validation fails (i.e. certificate is rejected), and there is no administrative override available to accept such certificate.
 
 *FCS_DTLSS_EXT.2.3*
 
 [arabic, start=316]
 . The evaluator shall send a client certificate with an identifier that does not match an expected identifier and verify that the server denies the connection.
+
+*FCS_DTLSS_EXT.2.4*
+[arabic, start=316]
+. The evaluator shall perform the following tests:
+
+. Test 1: [conditional]: The evaluator shall perform the following tests if “present a DTLS 1.0 Certificate Request message” is selected:
+[loweralpha]
+.. The evaluator shall perform a DTLS 1.0 handshake and examine the Certificate Request message. The evaluator shall verify the ClientCertificateTypes match those specified in the requirement.
+.. The evaluator shall establish a DTLS 1.0 connection and authenticate the client using each selected ClientCertificateType. The evaluator shall verify the connection succeeds.
+. Test 2: [conditional]: If “present a [selection: DTLS 1.2, DTLS 1.3] Certificate Request message” is selected, the evaluator shall perform the following tests for each selected version of DTLS:
+[loweralpha]
+.. The evaluator shall examine the Certificate Request message. The evaluator shall verify that the SignatureAndHashAlgorithms (DTLS 1.2) or the SignatureSchemes (DTLS 1.3) match the SignatureAndHashAlgorithms specified in the requirement.
+.. The evaluator shall establish a connection and authenticate the client using each selected SignatureAndHashAlgorithm. The evaluator shall verify the connection succeeds.
++
+Remark: The server must ensure the DTLS handshake is valid (e.g. certificate key, message formatting, hashes, and signatures), except for using a SignatureScheme not proposed by the client. The selected legacy SignatureScheme shall be as similar to one of the supported SignatureSchemes as possible. For example: 1) ecdsa_sha1 shall not be used if the TOE only supports RSA signatures, 2) ecdsa_sha1 must use a supported ECDSA curve or P-256 if only EdDSA curves are supported.
+. Test 3: [conditional]: If DTLS 1.3 is supported, the evaluator shall perform the following tests if “present the signature_algorithms_cert extension” is selected:
+[loweralpha]
+.. The evaluator shall examine the Certificate Request message and verify it contains the signature_algorihtms_cert extension and the SignatureSchemes match the SignatureSchemes specified in the requirement.
+.. The evaluator shall establish a TLS connection and perform client authentication using a certificate chain using each of the SignatureSchemes specified by the requirement. The evaluator shall ensure the signatures used in the certificate chain are consistent with the SignatureScheme being tested.
+.. The evaluator shall attempt to establish the connection using a test client that sends a certificate chain in the client Certificate message using one of the legacy SignatureSchemes (i.e. rsa_pkcs1_sha1 or ecdsa_sha1). The evaluator shall verify the connection fails.
++
+Remark: The server must ensure the TLS handshake is valid (e.g. certificate key, Certificate Verify message, message formatting, hashes, and signatures), except for the certificate chain using a SignatureScheme not proposed by the client. The selected legacy SignatureScheme shall be as similar to one of the supported SignatureSchemes as possible. For example: 1) ecdsa_sha1 shall not be used if the TOE only supports RSA signatures, 2) ecdsa_sha1 must use a supported ECDSA curve or P-256 if only EdDSA curves are supported.
 
 ==== FCS_TLSC_EXT.2 Extended: TLS Client support for mutual authentication
 
@@ -1602,7 +1630,8 @@ Some TOEs may set up the registration channel before the enablement step is carr
 
 *FCS_TLSC_EXT.2.1*
 
-(covered by FCS_TLSC_EXT.1.1 Test 1 and testing for FIA_X.509_EXT.).
+[loweralpha]
+.. (covered by FCS_TLSC_EXT.1.1 Test 1 and testing for FIA_X.509_EXT.*).
 
 ==== FCS_TLSC_EXT.3 Extended: TLS Client support for renegotiation (TLSv1.1/v1.2 only)
 
@@ -1636,20 +1665,25 @@ Some TOEs may set up the registration channel before the enablement step is carr
 
 ===== TSS
 
-*FCS_TLSS_EXT.2.1 and FCS_TLSS_EXT.2.2*
+*FCS_TLSS_EXT.2.1*
 
 [arabic, start=320]
 . The evaluator shall ensure that the TSS description required per FIA_X509_EXT.2.1 includes the use of client-side certificates for TLS mutual authentication.
-. The evaluator shall verify the TSS describes how the TSF uses certificates to authenticate the TLS client. The evaluator shall verify the TSS describes if the TSF supports any fallback authentication functions (e.g. username/password, challenge response) the TSF uses to authenticate TLS clients that do not present a certificate. If fallback authentication functions are supported, the evaluator shall verify the TSS describes whether the fallback authentication functions can be disabled.
+. The evaluator shall verify the TSS describes how the TSF uses certificates to authenticate the TLS client and how the TOE reacts in case either the client does not send a client certificate or the verification of the client certificate fails. The evaluator shall verify the TSS describes if the TSF supports any fallback authentication functions (e.g. username/password, challenge response) the TSF uses to authenticate TLS clients that do not present a certificate. If fallback authentication functions are supported, the evaluator shall verify the TSS describes whether the fallback authentication functions can be disabled.
 
 *FCS_TLSS_EXT.2.3*
 
 [arabic, start=322]
 . The evaluator shall verify that the TSS describes which types of identifiers are supported during client authentication (e.g. Fully Qualified Domain Name (FQDN)). If FQDNs are supported, the evaluator shall verify that the TSS describes that corresponding identifiers are matched according to RFC6125. For all other types of identifiers, the evaluator shall verify that the TSS describes how these identifiers are parsed from the certificate, what the expected identifiers are and how the parsed identifiers from the certificate are matched against the expected identifiers.
 
+*FCS_TLSS_EXT.2.4*
+
+[arabic, start=322]
+. The evaluator shall verify that TSS describes the signature_algorithm extension and whether the required behavior is performed by default or may be configured.
+
 ===== Guidance Documentation
 
-*FCS_TLSS_EXT.2.1 and FCS_TLSS_EXT.2.2*
+*FCS_TLSS_EXT.2.1*
 
 [arabic, start=323]
 . If the TSS indicates that mutual authentication using X.509v3 certificates is used, the evaluator shall verify that the AGD guidance includes instructions for configuring the client-side certificates for TLS mutual authentication.
@@ -1660,6 +1694,11 @@ Some TOEs may set up the registration channel before the enablement step is carr
 [arabic, start=325]
 . The evaluator shall ensure that the AGD guidance describes the configuration of expected identifier(s) for X.509 certificate-based authentication of TLS clients. The evaluator ensures this description includes all types of identifiers described in the TSS and, if claimed, configuration of the TOE to use a directory server.
 
+*FCS_TLSS_EXT.2.4*
+
+[arabic, start=325]
+. If the TSS indicates that the signature_algorithm extension must be configured to meet the requirement, the evaluator shall verify that AGD guidance includes configuration of the signature_algorithm extension.
+
 ===== Tests
 
 [arabic, start=326]
@@ -1668,28 +1707,47 @@ Some TOEs may set up the registration channel before the enablement step is carr
 *FCS_TLSS_EXT.2.1 and FCS_TLSS_EXT.2.2*
 
 [arabic, start=327]
-. Test 1a [conditional]: If the TOE requires or can be configured to require a client certificate, the evaluator shall configure the TOE to require a client certificate and send a Certificate Request to the client. The evaluator shall attempt a connection while sending a certificate_list structure with a length of zero in the Client Certificate message. The evaluator shall verify that the handshake is not finished successfully and no application data flows.
-. Test 1b [conditional]: If the TOE supports fallback authentication functions and these functions cannot be disabled. The evaluator shall configure the fallback authentication functions on the TOE and configure the TOE to send a Certificate Request to the client. The evaluator shall attempt a connection while sending a certificate_list structure with a length of zero in the Client Certificate message. The evaluator shall verify the TOE authenticates the connection using the fallback authentication functions as described in the TSS.
+. Test 1a [conditional]: If the 'hard fail' option has been selected in FCS_TLSS_EXT.2.1, the evaluator shall configure the TOE to require a client certificate and send a Certificate Request to the client. The evaluator shall attempt a connection while sending a certificate_list structure with a length of zero in the Client Certificate message. The evaluator shall verify that the handshake is not finished successfully and no application data flows.
+. Test 1b [conditional]: If the 'soft fail' option has been selected in FCS_TLSS_EXT.2.1, the evaluator shall configure the TOE to require a client certificate and configure the TOE to send a Certificate Request to the client. The evaluator shall attempt a connection while sending a certificate_list structure with a length of zero in the Client Certificate message. The evaluator verifies the client remains unauthenticated (e.g. requires application layer authentication tested according to the related SFRs for this application layer authentication) or is restricted to unauthenticated operations.
 . Note: Testing the validity of the client certificate is performed as part of X.509 testing.
-. Test 2 [conditional]: If TLS 1.2 is claimed for the TOE, the evaluator shall configure the server to send a certificate request to the client without the supported_signature_algorithm used by the client's certificate. The evaluator shall attempt a connection using the client certificate and verify that the connection is denied.
-. Test 3: The aim of this test is to check the response of the server when it receives a client identity certificate that is signed by an impostor CA (either Root CA or intermediate CA). To carry out this test the evaluator shall configure the client to send a client identity certificate with an issuer field that identifies a CA recognised by the TOE as a trusted CA, but where the key used for the signature on the client certificate does not correspond to the CA certificate trusted by the TOE (meaning that the client certificate is invalid because its certification path does not terminate in the claimed CA certificate). The evaluator shall verify that the attempted connection is denied.
-. Test 4: The evaluator shall configure the client to send a certificate with the Client Authentication purpose in the extendedKeyUsage field and verify that the server accepts the attempted connection. The evaluator shall repeat this test without the Client Authentication purpose and shall verify that the server denies the connection. Ideally, the two certificates should be identical except for the Client Authentication purpose.
-. Test 5: The evaluator shall perform the following modifications to the traffic:
+. Test 2: The aim of this test is to check the response of the server when it receives a client identity certificate that is signed by an impostor CA (either Root CA or intermediate CA). To carry out this test the evaluator shall configure the client to send a client identity certificate with an issuer field that identifies a CA recognised by the TOE as a trusted CA, but where the key used for the signature on the client certificate does not correspond to the CA certificate trusted by the TOE (meaning that the client certificate is invalid because its certification path does not terminate in the claimed CA certificate). The evaluator shall verify that the attempted connection is denied.
+. Test 3: The evaluator shall configure the client to send a certificate with the Client Authentication purpose in the extendedKeyUsage field and verify that the server accepts the attempted connection. The evaluator shall repeat this test without the Client Authentication purpose and shall verify that the server denies the connection. Ideally, the two certificates should be identical except for the Client Authentication purpose.
+. Test 4: The evaluator shall perform the following modifications to the traffic:
 [loweralpha]
-.. Configure the server to require mutual authentication and then connect to the server with a client configured to send a client certificate that is signed by a Certificate Authority trusted by the TOE. The evaluator shall verify that the server accepts the connection.
-.. Configure the server to require mutual authentication and then modify a byte in the signature block of the client’s Certificate Verify handshake message (see RFC5246 Sec 7.4.8). The evaluator shall verify that the server rejects the connection.
+.. [conditional]: Perform this test only if support of TLSv1.1 or TLSv1.2 is claimed. Configure the server to require mutual authentication and then connect to the server with a client configured to send a client certificate that is signed by a Certificate Authority trusted by the TOE. The evaluator shall verify that the server accepts the connection.
+.. [conditional]: Perform this test only if support of TLSv1.1 or TLSv1.2 is claimed. Configure the server to require mutual authentication and then modify a byte in the signature block of the client’s Certificate Verify handshake message (see RFC5246 Sec 7.4.8). The evaluator shall verify that the server rejects the connection.
 
 [arabic, start=334]
 . Note: Testing the validity of the client certificate is performed as part of X.509 testing.
-. The evaluator shall demonstrate that using an invalid certificate results in the function failing as follows:
-. Test 6: Using the administrative guidance, the evaluator shall load a CA certificate or certificates needed to validate the presented certificate used to authenticate an external entity and demonstrate that the function succeeds, and a trusted channel can be established.
-. Test 7: The evaluator shall then change the presented certificate(s) so that validation fails and show that the certificate is not automatically accepted. The evaluator shall repeat this test to cover the selected types of failure defined in the SFR (i.e. the selected ones from failed matching of the reference identifier, failed validation of the certificate path, failed validation of the expiration date, failed determination of the revocation status). The evaluator performs the action indicated in the SFR selection observing the TSF resulting in the expected state for the trusted channel (e.g. trusted channel was established) covering the types of failure for which an override mechanism is defined.
-. Test 8 [conditional]: The purpose of this test is to verify that only selected certificate validation failures could be administratively overridden. If any override mechanism is defined for failed certificate validation, the evaluator shall configure a new presented certificate that does not contain a valid entry in one of the mandatory fields or parameters (e.g. inappropriate value in extendedKeyUsage field) but is otherwise valid and signed by a trusted CA. The evaluator shall confirm that the certificate validation fails (i.e. certificate is rejected), and there is no administrative override available to accept such certificate.
+. Test 5 [conditional]: The purpose of this test is to verify that only selected certificate validation failures could be administratively overridden. If any override mechanism is defined for failed certificate validation, the evaluator shall configure a new presented certificate that does not contain a valid entry in one of the mandatory fields or parameters (e.g. inappropriate value in extendedKeyUsage field) but is otherwise valid and signed by a trusted CA. The evaluator shall confirm that the certificate validation fails (i.e. certificate is rejected), and there is no administrative override available to accept such certificate.
 
 *FCS_TLSS_EXT.2.3*
 
 [arabic, start=339]
 . The evaluator shall send a client certificate with an identifier that does not match an expected identifier and verify that the server denies the connection.
+
+
+*FCS_TLSS_EXT.2.4*
+
+[arabic, start=339]
+. The evaluator shall perform the following tests:
+. Test 1 [conditional]: The evaluator shall perform the following tests if “present a TLS1.1 Certificate Request message” is selected:
+[loweralpha]
+.. The evaluator shall perform a TLS1.1 handshake and examine the Certificate Request message. The evaluator shall verify the ClientCertificateTypes match those specified in the requirement.
+.. The evaluator shall establish a TLS1.1 connection and authenticate the client using each selected ClientCertificateType. The evaluator shall verify the connection succeeds. 
+. Test 2 [conditional]: If “present a [selection: TLSv1.2, TLSv1.3] Certificate Request message” is selected, the evaluator shall perform the following tests for each selected version of TLS:
+[loweralpha]
+.. The evaluator shall examine the Certificate Request message. The evaluator shall verify that the SignatureAndHashAlgorithms (TLSv1.2) or the SignatureSchemes (TLSv1.3) match the SignatureAndHashAlgorithms specified in the requirement.
+.. The evaluator shall establish a connection and authenticate the client using each selected SignatureAndHashAlgorithm. The evaluator shall verify the connection succeeds.
++
+Remark: The server must ensure the TLS handshake is valid (e.g. certificate key, message formatting, hashes, and signatures), except for using a SignatureScheme not proposed by the client. The selected legacy SignatureScheme shall be as similar to one of the supported SignatureSchemes as possible. For example: 1) ecdsa_sha1 shall not be used if the TOE only supports RSA signatures, 2) ecdsa_sha1 must use a supported ECDSA curve or P-256 if only EdDSA curves are supported.
+. Test 3 [conditional]: If TLSv1.3 is supported, the evaluator shall perform the following tests if “present the signature_algorithms_cert extension” is selected:
+[loweralpha]
+.. The evaluator shall examine the Certificate Request message and verify it contains the signature_algorihtms_cert extension and the SignatureSchemes match the SignatureSchemes specified in the requirement.
+.. The evaluator shall establish a TLS connection and perform client authentication using a certificate chain using each of the SignatureSchemes specified by the requirement. The evaluator shall ensure the signatures used in the certificate chain are consistent with the SignatureScheme being tested.
+.. The evaluator shall attempt to establish the connection using a test client that sends a certificate chain in the client Certificate message using one of the legacy SignatureSchemes (i.e. rsa_pkcs1_sha1 or ecdsa_sha1). The evaluator shall verify the connection fails.
++
+Remark: The server must ensure the TLS handshake is valid (e.g. certificate key, Certificate Verify message, message formatting, hashes, and signatures), except for the certificate chain using a SignatureScheme not proposed by the client. The selected legacy SignatureScheme shall be as similar to one of the supported SignatureSchemes as possible. For example: 1) ecdsa_sha1 shall not be used if the TOE only supports RSA signatures, 2) ecdsa_sha1 must use a supported ECDSA curve or P-256 if only EdDSA curves are supported.
 
 ==== FCS_TLSS_EXT.3 Extended: TLS Server support for renegotiation (TLSv1.1/v1.2 only)
 
@@ -1718,6 +1776,7 @@ Some TOEs may set up the registration channel before the enablement step is carr
 . Test 1: The evaluator shall use a network packet analyzer/sniffer to capture the traffic between the two TLS endpoints. The evaluator shall verify that the “renegotiation_info” field is included in the ServerHello message.
 . Test 2: The evaluator shall modify the length portion of the field in the ClientHello message in the initial handshake to be non-zero and verify that the server sends a failure and terminates the connection. The evaluator shall verify that a properly formatted field results in a successful TLS connection.
 . Test 3: The evaluator shall modify the "client_verify_data" or "server_verify_data" value in the ClientHello message received during secure renegotiation and verify that the server terminates the connection.
+
 
 == Evaluation Activities for Selection-Based Requirements
 

--- a/ND Supporting Document 2_2.adoc
+++ b/ND Supporting Document 2_2.adoc
@@ -1749,18 +1749,18 @@ Remark: The server must ensure the TLS handshake is valid (e.g. certificate key,
 +
 Remark: The server must ensure the TLS handshake is valid (e.g. certificate key, Certificate Verify message, message formatting, hashes, and signatures), except for the certificate chain using a SignatureScheme not proposed by the client. The selected legacy SignatureScheme shall be as similar to one of the supported SignatureSchemes as possible. For example: 1) ecdsa_sha1 shall not be used if the TOE only supports RSA signatures, 2) ecdsa_sha1 must use a supported ECDSA curve or P-256 if only EdDSA curves are supported.
 
-==== FCS_TLSS_EXT.3 Extended: TLS Server support for renegotiation (TLSv1.1/v1.2 only)
+==== FCS_TLSS_EXT.3 Extended: TLS Server support for secure renegotiation (TLSv1.1/v1.2 only)
 
 ===== TSS
 
-*FCS_TLSS_EXT.3.1 and FCS_TLSS_EXT.3.2*
+*FCS_TLSS_EXT.3.1
 
 [arabic, start=328]
 . None.
 
 ===== Guidance Documentation
 
-*FCS_TLSS_EXT.3.1 and FCS_TLSS_EXT.3.2*
+*FCS_TLSS_EXT.3.1
 
 [arabic, start=329]
 . None
@@ -1770,7 +1770,7 @@ Remark: The server must ensure the TLS handshake is valid (e.g. certificate key,
 [arabic, start=330]
 . The evaluator shall perform the following tests. The following tests require connection with a client that supports secure renegotiation and the "renegotiation_info" extension.
 
-*FCS_TLSS_EXT.3.1 and FCS_TLSS_EXT.3.2*
+*FCS_TLSS_EXT.3.1
 
 [arabic, start=331]
 . Test 1: The evaluator shall use a network packet analyzer/sniffer to capture the traffic between the two TLS endpoints. The evaluator shall verify that the “renegotiation_info” field is included in the ServerHello message.

--- a/NDcPP_v2_2e.adoc
+++ b/NDcPP_v2_2e.adoc
@@ -2603,8 +2603,8 @@ _In a future version of this cPP TLS v1.2 will be required for all TOEs._
 
 *FCS_TLSC_EXT.1.2* The TSF shall verify that the presented identifier matches [selection: _the reference identifier per RFC 6125 section 6[.underline]##,## IPv4 address in CN or SAN, IPv6 address in the CN or SAN, IPv4 address in SAN, IPv6 address in the SAN, the identifier per RFC 5280 Appendix A using [selection: id-at-commonName, id-at-countryName, id-at-dnQualifier, id-at-generationQualifier, id-at-givenName, id-at-initials, id-at-localityName, id-at-name, id-at-organizationalUnitName, id-at-organizationName, id-at-pseudonym, id-at-serialNumber, id-at-stateOrProvinceName, id-at-surname, id-at-title] and no other attribute types_].
 
-[arabic, start=105]
-. {blank}
+*_Application Note {counter:appnote_count}_*
+
 
 Where TLS is used for connections to/from non-TOE entities (relevant to FTP_ITC and FTP_TRP), the ST author shall select RFC 6125. For distributed TOEs (TLS connections relevant to FPT_ITT), the ST author may select either RFC 6125 or RFC 5280. If RFC 5280 is selected, the selection is completed by listing the AttributeType (e.g. ‘id-at-serialNumber’) as defined in RFC 5280 Appendix A. The selection should only list those attributes that are significant (i.e. those which are used by the client for reference identifier matching), though the Subject field (DN) may contain other attribute types that are not significant for the purpose of reference identifier matching. In the TSS the ST author describes which attribute type, or combination of attributes types, are used by the client to match the presented identifier with the configured identifier. The ST author selects “_the reference identifier per RFC 6125 section 6” for TOEs that support FQDN, SRV, and URI identifiers._
 
@@ -2623,8 +2623,8 @@ Finally, the client should avoid constructing reference identifiers using wildca
 
 ].
 
-[arabic, start=106]
-. {blank}
+*_Application Note {counter:appnote_count}_*
+
 
 ‘Revocation status’ refers to an OCSP or CRL response that indicates the presented certificate is invalid. Inability to make a connection to determine validity shall be handled as specified in FIA_X509_EXT.2.2. If the revocation status of a certificate received by the TOE is ambiguous (e.g. ‘unknown’), this should be treated similar to the situation where no connection could be established to the revocation server and the option ‘determine the revocation status’ could be chosen for this.
 
@@ -2636,8 +2636,8 @@ If TLS is selected in FPT_ITT, then certificate validity is tested in accordance
 
 *FCS_TLSC_EXT.1.4* The TSF shall [selection: _not present the Supported Elliptic Curves/Supported Groups Extension, present the Supported Elliptic Curves/Supported Groups Extension with the following curves/groups:_ [selection: _secp256r1, secp384r1, secp521r1, ffdhe2048, ffdhe3072, ffdhe4096, ffdhe6144, ffdhe8192_] _and no other curves/groups_] in the Client Hello.
 
-[arabic, start=107]
-. {blank}
+*_Application Note {counter:appnote_count}_*
+
 
 If ciphersuites with elliptic curves were selected in FCS_TLSC_EXT.1.1, a selection of one or more curves is required. If no ciphersuites with elliptic curves were selected in FCS_TLSC_EXT.1.1, then “not present the Support Elliptic Curves/Supported Groups Extension” should be selected.
 
@@ -2645,43 +2645,45 @@ This requirement limits the elliptic curves allowed for authentication and key a
 
 If ciphersuites with DHE key agreement were selected FCS_TLSC_EXT.1.1 and the TOE supports TLS FFC groups (e.g. ffdhe2048), this extension is required. This extension is not required if the TOE only supports non-TLS FFC groups (e.g. Group 14).
 
-*FCS_TLSS_EXT.1 TLS Server Protocol Without Mutual Authentication*
+*FCS_TLSS_EXT.1 TLS Server Protocol*
 
-*FCS_TLSS_EXT.1.1* The TSF shall implement [selection: __TLS 1.2 (RFC 5246), TLS 1.1 (RFC 4346)__[.underline]##]## and reject all other TLS and SSL versions. The TLS implementation will support the following ciphersuites:
+*FCS_TLSS_EXT.1.1* The TSF shall implement [selection: _TLS 1.3 (RFC 8446), TLS 1.2 (RFC 5246)_] and [selection: _TLS 1.1 (RFC 4346), no additional TLS version_] and reject all other TLS and SSL versions. The TLS implementation will support the following ciphersuites:
 
-____
-[selection:
+_[selection:_
 
-[.underline]#_select supported ciphersuites from List 1_] _and no other ciphersuites_#.
-____
+* _select supported ciphersuites for TLSv1.1 and/or TLSv1.2 from List 1_
 
-[arabic, start=108]
-. {blank}
+* _select supported ciphersuites for TLSv1.3 from List 2_
 
-The ciphersuites to be tested in the evaluated configuration are limited by this requirement and must be selected from the ciphersuites defined in List 1. The ST author should select the optional ciphersuites that are supported. Even though RFC 5246 mandates implementation of specific ciphers, there is no requirement to implement TLS_RSA_WITH_AES_128_CBC_SHA in order to claim conformance to this cPP.
+_]_ and no other ciphersuites.
 
-These requirements will be revisited as new TLS versions are standardized by the IETF.
+
+*_Application Note {counter:appnote_count}_*
+
+
+_The ciphersuites to be tested in the evaluated configuration are limited by this requirement and must be selected from the ciphersuites defined in List 1. The ST author should select the optional ciphersuites that are supported. Even though RFC 5246 mandates implementation of specific ciphers, this cPP depreciates use of SHA-1. Support for TLS_RSA_WITH_AES_128_CBC_SHA is not claimed in order to claim conformance to this cPP._
+
+
+_These requirements will be revisited as new TLS versions are standardized by the IETF._
 
 _In a future version of this cPP TLS v1.2 will be required for all TOEs._
 
 *FCS_TLSS_EXT.1.2* The TSF shall deny connections from clients requesting _SSL 2.0, SSL 3.0, TLS 1.0 and [selection: TLS 1.1, TLS 1.2, none]_.
 
-[arabic, start=109]
-. {blank}
+*_Application Note {counter:appnote_count}_*
+
 
 _All SSL versions and TLS v1.0 are denied. Any TLS versions not selected in FCS_TLSS_EXT.1.1 should be selected here. (If ‘none’ is the selection for this element then the ST author may omit the words “and none”.)_
 
 *FCS_TLSS_EXT.1.3* The TSF shall perform key establishment for TLS using [selection: _RSA with key size_ [selection: _2048 bits, 3072 bits, 4096 bits_]_, Diffie-Hellman parameters with size_ [selection: _2048 bits, 3072 bits, 4096 bits, 6144 bits, 8192 bits_]_, Diffie-Hellman groups_ [selection: _ffdhe2048, ffdhe3072, ffdhe4096, ffdhe6144, ffdhe8192, no other groups_]_, ECDHE curves_ [selection: _secp256r1, secp384r1, secp521r1] and no other curves_]].
 
-[arabic, start=110]
-. {blank}
+*_Application Note {counter:appnote_count}_*
 
 The appropriate options shall be selected in the ST according to the key establishment options supported by the TOE. FMT_SMF.1 requires the configuration of the key agreement parameters to establish the security strength of the TLS connection.
 
 *FCS_TLSS_EXT.1.4* The TSF shall support [selection: _no session resumption or session tickets, session resumption based on session IDs according to RFC 4346 (TLS1.1) or RFC 5246 (TLS1.2), session resumption based on session tickets according to RFC 5077_].
 
-[arabic, start=111]
-. {blank}
+*_Application Note {counter:appnote_count}_*
 
 _If the TOE does not support session resumption or session tickets, select 'no session resumption or session tickets’. If the TOE supports session resumption based on session IDs according to RFC 4346 (TLS1.1) or RFC 5246 (TLS1.2), select 'session resumption based on session IDs according to RFC 4346 (TLS1.1) or RFC 5246 (TLS1.2)'. If the TOE supports session resumption based on session tickets according to RFC 5077, select 'session resumption based on session tickets according to RFC 5077'._
 

--- a/NDcPP_v2_2e.adoc
+++ b/NDcPP_v2_2e.adoc
@@ -1197,6 +1197,7 @@ _The word ‘manage’ includes but is not limited to create, initialize, view, 
 ** _Ability to configure the cryptographic functionality;_
 ** _Ability to configure thresholds for SSH rekeying;_
 ** _Ability to configure the lifetime for IPsec SAs;_
+** _Ability to configure the list of supported (D)TLS ciphers;_
 ** _Ability to configure the interaction between TOE components;_
 ** _Ability to enable or disable automatic checking for updates or automatic updates;_
 ** _Ability to re-enable an Administrator account;_
@@ -1731,8 +1732,8 @@ _If FAU_STG_EXT.3/LocSpace is added to the ST, the ST has to make clear any situ
 
 * The TSF shall validate the revocation status of the certificate using [selection: _the Online Certificate Status Protocol (OCSP) as specified in RFC 6960, a Certificate Revocation List (CRL) as specified in RFC 5280 Section 6.3, Certificate Revocation List (CRL) as specified in RFC 5759 Section 5, no revocation method_]
 * The TSF shall validate the extendedKeyUsage field according to the following rules:
-** _Server certificates presented for TLS shall have the Server Authentication purpose (id-kp 1 with OID 1.3.6.1.5.5.7.3.1) in the extendedKeyUsage field._
-** _Client certificates presented for TLS shall have the Client Authentication purpose (id-kp 2 with OID 1.3.6.1.5.5.7.3.2) in the extendedKeyUsage field._
+** _Server certificates presented for DTLS/TLS shall have the Server Authentication purpose (id-kp 1 with OID 1.3.6.1.5.5.7.3.1) in the extendedKeyUsage field._
+** _Client certificates presented for DTLS/TLS shall have the Client Authentication purpose (id-kp 2 with OID 1.3.6.1.5.5.7.3.2) in the extendedKeyUsage field._
 ** _OCSP certificates presented for OCSP responses shall have the OCSP Signing purpose (id-kp 9 with OID 1.3.6.1.5.5.7.3.9) in the extendedKeyUsage field._
 
 *_Application Note {counter:appnote_count}_*
@@ -1962,7 +1963,7 @@ _The DTLS 1.3 Certificate Request message includes the algorithms as a list of  
 
 =====  FCS_TLSC_EXT & FCS_TLSS_EXT TLS Protocol
 
-TLS is not a required component of this cPP. If a TOE implements TLS, a corresponding selection in FPT_ITT.1, FTP_ITC.1, or FTP_TRP.1/Admin should be made to define what the TLS protocol is implemented to protect. If a corresponding option to support TLS has been selected in at least one of the SFRs named above, the corresponding selection-based TLS-related SFRs should be added to the ST from chap. B.3.1.6 (i.e. FCS_TLSC_EXT.1 and/or FCS_TLSS_EXT.1). The SFRs therein cover only the minimum TLS-related requirements without support for mutual authentication. The support for mutual authentication is optional when using TLS. If a TOE implements TLS with mutual authentication, the corresponding optional SFRs should be added to the ST from chap. A.7.1.1 (i.e. FCS_TLSC_EXT.2 and/or FCS_TLSS_EXT.2) in addition to the corresponding SFRs from chap. B.3.1.6.
+TLS is not a required component of this cPP. If a TOE implements TLS, a corresponding selection in FPT_ITT.1, FTP_ITC.1, or FTP_TRP.1/Admin should be made to define what the TLS protocol is implemented to protect. If a corresponding option to support TLS has been selected in at least one of the SFRs named above, the corresponding selection-based TLS-related SFRs should be added to the ST from chap. B.3.1.6 (i.e. FCS_TLSC_EXT.1 and/or FCS_TLSS_EXT.1). The SFRs therein cover only the minimum TLS-related requirements without support for mutual authentication. The support for mutual authentication is optional when using TLS. If a TOE implements TLS with mutual authentication, the corresponding optional SFRs should be added to the ST from chap. A.7.1.2 (i.e. FCS_TLSC_EXT.2 and/or FCS_TLSS_EXT.2) in addition to the corresponding SFRs from chap. B.3.1.6.
 
 A TOE may act as the client, the server, or both in TLS sessions. The requirement has been separated into TLS Client (FCS_TLSC_EXT) and TLS Server (FCS_TLSS_EXT) requirements to allow for these differences. If the TOE acts as the client during the claimed TLS sessions, the ST author should claim the corresponding FCS_TLSC_EXT requirements. If the TOE acts as the server during the claimed TLS sessions, the ST author should claim the corresponding FCS_TLSS_EXT requirements. If the TOE acts as both a client and server during the claimed TLS sessions, the ST author should claim the corresponding FCS_TLSC_EXT and FCS_TLSS_EXT requirements.
 
@@ -1988,11 +1989,16 @@ _Per RFC 5746, the client may present either the "renegotiation_info" extension 
 
 *FCS_TLSS_EXT.2 TLS Server Support for Mutual Authentication*
 
-*FCS_TLSS_EXT.2.1* The TSF shall support TLS communication with mutual authentication of TLS clients using X.509v3 certificates.
+*FCS_TLSS_EXT.2.1* The TSF shall support TLS communication with mutual authentication of TLS clients using X.509v3 certificates and shall [selection:
+
+* _reject the connection if the client either does not provide a client certificate at all or the client certificate cannot be successfully validated by the TOE (except for override mechanisms that might be defined in FCS_TLSS_EXT.2.2) ('hard fail')_
+* _accept the connection even if the client does not provide a client certificate at all, as long as a fall-back authentication is performed using one of the other authentication mechanisms defined in this cPP before any other TSF-mediated action is performed via this channel ('soft fail')_
 
 *_Application Note {counter:appnote_count}_*
 
 _The use of X.509v3 certificates for TLS is addressed in FIA_X509_EXT.2.1. This requirement adds that the client must be capable of presenting a certificate to a TLS server for TLS mutual authentication._
+
+_There are different behaviours of the TOE possible for the 'soft fail' option depending on the type of product, use case and actual implementation. It is quite common that in case the server requests the client certificate but the client does not present a certificate, the establishment of the TLS connection continues (up to the point where the connection is fully established) but fall-back authentication using one of the other authentication mechanisms defined in this cPP is enforced before any other TSF-mediated action can be performed (e.g. transfer of TSF data other than data needed for fall-back authentication; administration of the TOE). It is acceptable to establish the channel without fall-back authentication in case no TSF-mediated action is possible through this channel. For any channel that allows TSF-mediated actions, either successful client authentication through successful validation of the client's X.509 certificate or successful fall-back authentication using one of the other authentication mechanisms defined in this cPP is required._
 
 *FCS_TLSS_EXT.2.2* When establishing a trusted channel, by default the TSF shall not establish a trusted channel if the client certificate is invalid. The TSF shall also [selection:
 
@@ -2021,6 +2027,36 @@ _If the identifier is not a FQDN, then the TSS shall describe how the identifier
 
 _The client identifier may be in the Subject field or the Subject Alternative Name extension of the certificate. The expected identifier may either be configured, may be compared to the FQDN, IP address, username, or email address used by the client, or may be passed to a directory server for comparison._
 
+*FCS_TLSS_EXT.2.4* The TSF shall [selection:
+
+* _present a TLS1.1 Certificate Request message containing the following ClientCertificateTypes: [selection:_
+** _rsa_sign,_
+** _ecdsa_sign,_
+** _] and no other ClientCertificateTypes;_
+* _present a [selection: TLSv1.2, TLSv1.3] Certificate Request message containing the following algorithms: [selection:_
+** _rsa_pkcs1 with sha256(0x0401),_
+** _rsa_pkcs1 with sha384(0x0501),_
+** _rsa_pkcs1 with sha512(0x0601),_
+** _ecdsa_secp256r1 with sha256(0x0403),_
+** _ecdsa_secp384r1 with sha384(0x0503),_
+** _ecdsa_secp521r1 with sha512(0x0603),_
+** _rsa_pss_rsae with sha256(0x0804),_
+** _rsa_pss_rsae with sha384(0x0805),_
+** _rsa_pss_rsae with sha512(0x0806),_
+** _rsa_pss_pss with sha256(0x0809),_
+** _rsa_pss_pss with sha384(0x080a),_
+** _rsa_pss_pss with sha512(0x080b)_
+** _] and no other algorithms;_ +
+_]._
+
+*_Application Note {counter:appnote_count}_*
+
+_The selected ClientCertificateTypes and algorithms must be consistent with FCS_COP.1/SigGen and FCS_COP.1/Hash._
+
+_The TLS 1.2 Certificate Request message includes the algorithms as a list of  SignatureAndHashAlgorithms in the supported signature algorithms list. The signature algorithm is also specified in the certificate_types list._
+
+_The TLS 1.3 Certificate Request message includes the algorithms as a list of SignatureSchemes in the signature_algorithms extension._
+
 *FCS_TLSS_EXT.3 TLS Server Support for renegotiation (TLSv1.1/v1.2 only)*
 
 *FCS_TLSS_EXT.3.1* The product shall support the "renegotiation_info" TLS extension in accordance with RFC 5746.
@@ -2031,7 +2067,7 @@ _The client identifier may be in the Subject field or the Subject Alternative Na
 
 _This component may only be claimed for TLSv1.1 and TLSv1.2 but not TLSv1.3._
 
-_RFC 5746 defines an extension to TLS that binds renegotiation handshakes to the cryptography in the original handshake._
+_RFC 5746 defines an extension to TLS that binds renegotiation handshakes to the cryptography in the original handshake.
 
 [appendix]
 == Selection-Based Requirements
@@ -2141,7 +2177,7 @@ _TOE components are not required to monitor or audit connectivity or network out
 
 ===== FCS_DTLSC_EXT & FCS_DTLSS_EXT DTLS Protocol
 
-Datagram TLS (DTLS) is not a required component of the NDcPP. If a TOE implements DTLS, a corresponding selection in FTP_ITC.1, FTP_TRP.1/Admin, or FPT_ITT.1 should be made to define what the DTLS protocol is implemented to protect. If a corresponding option to support DTLS has been selected in at least one of the SFRs named above, the corresponding selection-based DTLS-related SFRs should be added to the ST from chap. B.3.1.1 (i.e. FCS_DTLSC_EXT.1 and/or FCS_DTLSS_EXT.1). The SFRs therein cover only the minimum DTLS-related requirements without support for mutual authentication. The support for mutual authentication is optional when using DTLS. If a TOE implements DTLS with mutual authentication the corresponding optional SFRs should be added to the ST from chap. A.7.1.1 (i.e. FCS_DTLSC_EXT.2 and/or FCS_DTLSS_EXT.2) in addition to the corresponding SFRs from chap.B.3.1.1.
+Datagram TLS (DTLS) is not a required component of the NDcPP. If a TOE implements DTLS, a corresponding selection in FTP_ITC.1, FTP_TRP.1/Admin, or FPT_ITT.1 should be made to define what the DTLS protocol is implemented to protect. If a corresponding option to support DTLS has been selected in at least one of the SFRs named above, the corresponding selection-based DTLS-related SFRs should be added to the ST from chap. B.3.1.1 (i.e. FCS_DTLSC_EXT.1 and/or FCS_DTLSS_EXT.1). The SFRs therein cover only the minimum DTLS-related requirements without support for mutual authentication/client authentication. The support for mutual authentication is optional when using DTLS. If a TOE implements DTLS with mutual authentication/client authentication the corresponding optional SFRs should be added to the ST from chap. A.7.1.1 (i.e. FCS_DTLSC_EXT.2 and/or FCS_DTLSS_EXT.2) in addition to the corresponding SFRs from chap.B.3.1.1.
 
 The decision whether to include the support for protocol-level mutual authentication in the scope of the evaluation is regarded as part of the TOE boundary definition. These SFRs can be included in a conforming ST at the discretion of the ST author, even if the conformance statement of the cPP requires exact conformance. It is not mandatory to implement mutually authenticated DTLS in order to conform to this cPP.
 
@@ -2152,6 +2188,8 @@ If the TOE acts as the client during the claimed DTLS sessions, the ST author sh
 To ensure audit requirements are properly met, a DTLS receiver may need to monitor the DTLS connection state at the application layer. When no data is received from a DTLS connection for a long time (where the application decides what ‘long’ means), the receiver should send a close_notify alert message and close the connection.
 
 If the TOE acts as the server during the claimed DTLS sessions, the ST author should claim the corresponding FCS_DTLSS_EXT requirements. In this case the TOE needs to claim at least the FCS_DTLSS_EXT.1 requirements in chap. B.3.1.1 (no support for mutual authentication). If the TOE acts as DTLS server and in addition also supports mutual authentication, the FCS_DTLSS_EXT.2 requirements in chap. A.7.1.1 need to be claimed in addition. If the TOE acts as both a client and server during the claimed DTLS sessions, the ST author should claim the corresponding FCS_DTLSC_EXT and FCS_DTLSS_EXT requirements.
+
+Due to the structural differences between TLSv1.1/v1.2 on the one hand and TLSv1.3 on the other hand, some of the requirements are separated. The lists of DTLS-/TLS-related ciphersuites, for example, are kept separately as follows.
 
 *FCS_DTLSC_EXT.1 DTLS Client Protocol*
 
@@ -2700,11 +2738,13 @@ _For any configurable threshold related to this requirement the guidance documen
 
 =====  FCS_TLSC_EXT & FCS_TLSS_EXT TLS Protocol
 
-TLS is not a required component of this cPP. If a TOE implements TLS, a corresponding selection in FPT_ITT.1, FTP_ITC.1, or FTP_TRP.1/Admin should be made to define what the TLS protocol is implemented to protect. If a corresponding option to support TLS has been selected in at least one of the SFRs named above, the corresponding selection-based TLS-related SFRs should be added to the ST from chap. B.3.1.6 (i.e. FCS_TLSC_EXT.1 and/or FCS_TLSS_EXT.1). The SFRs therein cover only the minimum TLS-related requirements without support for mutual authentication. The support for mutual authentication is optional when using TLS. If a TOE implements TLS with mutual authentication the corresponding optional SFRs should be added to the ST from chap. A.7.1.2 (i.e. FCS_TLSC_EXT.2 and/or FCS_TLSS_EXT.2) in addition to the corresponding SFRs from chap. B.3.1.6.
+TLS is not a required component of this cPP. If a TOE implements TLS, a corresponding selection in FPT_ITT.1, FTP_ITC.1, or FTP_TRP.1/Admin should be made to define what the TLS protocol is implemented to protect. If a corresponding option to support TLS has been selected in at least one of the SFRs named above, the corresponding selection-based TLS-related SFRs should be added to the ST from chap. B.3.1.6 (i.e. FCS_TLSC_EXT.1 and/or FCS_TLSS_EXT.1). The SFRs therein cover only the minimum TLS-related requirements without support for mutual authentication/client authentication. The support for mutual authentication is optional when using TLS. If a TOE implements TLS with mutual authentication/client authentication the corresponding optional SFRs should be added to the ST from chap. A.7.1.2 (i.e. FCS_TLSC_EXT.2 and/or FCS_TLSS_EXT.2) in addition to the corresponding SFRs from chap. B.3.1.6.
 
 A TOE may act as the client, the server, or both in TLS sessions. The requirement has been separated into TLS Client (FCS_TLSC_EXT) and TLS Server (FCS_TLSS_EXT) requirements to allow for these differences. If the TOE acts as the client during the claimed TLS sessions, the ST author should claim the corresponding FCS_TLSC_EXT requirements. If the TOE acts as the server during the claimed TLS sessions, the ST author should claim the corresponding FCS_TLSS_EXT requirements. If the TOE acts as both a client and server during the claimed TLS sessions, the ST author should claim the corresponding FCS_TLSC_EXT and FCS_TLSS_EXT requirements.
 
 Additionally, TLS may or may not be performed with client authentication. The ST author shall claim FCS_TLSC_EXT.1 and/or FCS_TLSS_EXT.1 if the TOE does not support client authentication. The ST author should claim FCS_TLSC_EXT.2 and/or FCS_TLSS_EXT.2 if client authentication is performed by the TOE.
+
+Due to the structural differences between TLSv1.1/v1.2 on the one hand and TLSv1.3 on the other hand, some of the requirements are separated. The lists of DTLS-/TLS-related ciphersuites, for example, are kept separately as follows.
 
 The following list contains all DTLS-/TLS-related ciphersuites supported by this cPP.
 
@@ -4039,7 +4079,10 @@ FIA_X509_EXT.1 X.509 Certificate Validation
 FIA_X509_EXT.2 X.509 Certificate Authentication
 ____
 
-*FCS_TLSS_EXT.2.1* The TSF shall support TLS communication with mutual authentication of TLS clients using X.509v3 certificates.
+*FCS_TLSS_EXT.2.1* The TSF shall support TLS communication with mutual authentication of TLS clients using X.509v3 certificates and shall [selection:
+
+* _reject the connection if the client either does not provide a client certificate at all or the client certificate cannot be successfully validated by the TOE (except for override mechanisms that might be defined in FCS_TLSS_EXT.2.2) ('hard fail')_
+* _accept the connection even if the client does not provide a client certificate at all, as long as a fall-back authentication is performed using one of the other authentication mechanisms defined in this cPP before any other TSF-mediated action is performed via this channel ('soft fail')_
 
 *FCS_TLSS_EXT.2.2* When establishing a trusted channel, by default the TSF shall not establish a trusted channel if the client certificate is invalid. The TSF shall also [selection:
 
@@ -4049,6 +4092,28 @@ ____
 ].
 
 *FCS_TLSS_EXT.2.3* The TSF shall not establish a trusted channel if the identifier contained in a certificate does not match an expected identifier for the client. If the identifier is a Fully Qualified Domain Name (FQDN), then the TSF shall match the identifiers according to RFC 6125, otherwise the TSF shall parse the identifier from the certificate and match the identifier against the expected identifier of the client as described in the TSS.
+
+*FCS_TLSS_EXT.2.4* The TSF shall [selection:
+
+* _present a TLS1.1 Certificate Request message containing the following ClientCertificateTypes: [selection:_
+** _rsa_sign,_
+** _ecdsa_sign,_
+** _] and no other ClientCertificateTypes;_
+* _present a [selection: TLSv1.2, TLSv1.3] Certificate Request message containing the following algorithms: [selection:_
+** _rsa_pkcs1 with sha256(0x0401),_
+** _rsa_pkcs1 with sha384(0x0501),_
+** _rsa_pkcs1 with sha512(0x0601),_
+** _ecdsa_secp256r1 with sha256(0x0403),_
+** _ecdsa_secp384r1 with sha384(0x0503),_
+** _ecdsa_secp521r1 with sha512(0x0603),_
+** _rsa_pss_rsae with sha256(0x0804),_
+** _rsa_pss_rsae with sha384(0x0805),_
+** _rsa_pss_rsae with sha512(0x0806),_
+** _rsa_pss_pss with sha256(0x0809),_
+** _rsa_pss_pss with sha384(0x080a),_
+** _rsa_pss_pss with sha512(0x080b)_
+** _] and no other algorithms;_ +
+_]._
 
 *FCS_TLSS_EXT.3 TLS Server Support for renegotiation (TLSv1.1/v1.2 only)*
 ____
@@ -4078,6 +4143,7 @@ ____
 *FCS_TLSS_EXT.3.1* The product shall support the "renegotiation_info" TLS extension in accordance with RFC 5746.
 
 *FCS_TLSS_EXT.3.2* The product shall include the renegotiation_info extension in ServerHello messages.
+
 
 === Identification and Authentication (FIA)
 

--- a/NDcPP_v2_2e.adoc
+++ b/NDcPP_v2_2e.adoc
@@ -2920,15 +2920,17 @@ _The use of the early data extension and the post-handshake client authenticatio
 
 _The use of out-of-band provisioned pre-shared keys creates a potential security concern since the entropy used to generate the PSK is outside of the control of the TOE.  PSKs are used in TLSv1.3 to provide session resumption; however, in this case, the TSF is responsible for generating appropriately strong keying material.  Use of (EC)DHE further enhances security when using PSKs by providing forward secrecy._
 
+*FCS_TLSS_EXT.1 TLS Server Protocol*
+
 *FCS_TLSS_EXT.1.1* The TSF shall implement [selection: _TLS 1.3 (RFC 8446), TLS 1.2 (RFC 5246)_] and [selection: _TLS 1.1 (RFC 4346), no additional TLS version_] and reject all other TLS and SSL versions. The TLS implementation will support the following ciphersuites:
 
-_[selection:_
+[selection:
 
 * _select supported ciphersuites for TLSv1.1 and/or TLSv1.2 from List 1_
 
 * _select supported ciphersuites for TLSv1.3 from List 2_
 
-_]_ and no other ciphersuites.
+] and no other ciphersuites.
 
 
 *_Application Note {counter:appnote_count}_*
@@ -2941,24 +2943,79 @@ _These requirements will be revisited as new TLS versions are standardized by th
 
 _In a future version of this cPP TLS v1.2 will be required for all TOEs._
 
-*FCS_TLSS_EXT.1.2* The TSF shall deny connections from clients requesting _SSL 2.0, SSL 3.0, TLS 1.0 and [selection: TLS 1.1, TLS 1.2, none]_.
+*_Application Note {counter:appnote_count}_*
+
+_The TOE shall not negotiate sessions using any of the SSL versions as well as TLSv1.0._
+
+*FCS_TLSS_EXT.1.2* The TSF shall authenticate itself using X.509 certificate(s) using [selection: _RSA with key size [selection: 2048 bits, 3072 bits, 4096 bits]; ECDSA over NIST curves [selection: secp256r1, secp384r1, secp521r1] and no other curves_].
 
 *_Application Note {counter:appnote_count}_*
 
+_The selected algorithms and key sizes must be consistent with FCS_COP.1/SigGen and FCS_CKM.1. NDcPP does not support raw public keys as defined in RFC8446._
 
-_All SSL versions and TLS v1.0 are denied. Any TLS versions not selected in FCS_TLSS_EXT.1.1 should be selected here. (If ‘none’ is the selection for this element then the ST author may omit the words “and none”.)_
+_If the ST includes TLS 1.1 or TLS 1.2 in FCS_TLSS_EXT.1.1, the selected algorithms must be consistent with the ciphersuites selected in FCS_TLSS_EXT.1.1._
 
-*FCS_TLSS_EXT.1.3* The TSF shall perform key establishment for TLS using [selection: _RSA with key size_ [selection: _2048 bits, 3072 bits, 4096 bits_]_, Diffie-Hellman parameters with size_ [selection: _2048 bits, 3072 bits, 4096 bits, 6144 bits, 8192 bits_]_, Diffie-Hellman groups_ [selection: _ffdhe2048, ffdhe3072, ffdhe4096, ffdhe6144, ffdhe8192, no other groups_]_, ECDHE curves_ [selection: _secp256r1, secp384r1, secp521r1] and no other curves_]].
+*FCS_TLSS_EXT.1.3* The TSF shall perform key exchange using: [selection: 
+
+* _RSA key establishment with key size [selection: 2048 bits, 3072 bits, 4096 bits];_ 
+
+* _EC Diffie-Hellman key agreement over NIST curves [selection: secp256r1, secp384r1, secp521r1] and no other curves;_ 
+
+* _Diffie-Hellman parameters [selection: of size 2048 bits, of size 3072 bits, of size 4096 bits, of size 6144 bits, of size 8192 bits, ffdhe2048, ffdhe3072, ffdhe4096, ffdhe6144, ffdhe8192]_
+
+].
 
 *_Application Note {counter:appnote_count}_*
 
-The appropriate options shall be selected in the ST according to the key establishment options supported by the TOE. FMT_SMF.1 requires the configuration of the key agreement parameters to establish the security strength of the TLS connection.
+_The selected algorithms and key sizes must be consistent with FCS_CKM.2_
 
-*FCS_TLSS_EXT.1.4* The TSF shall support [selection: _no session resumption or session tickets, session resumption based on session IDs according to RFC 4346 (TLS1.1) or RFC 5246 (TLS1.2), session resumption based on session tickets according to RFC 5077_].
+_The following table provides the ST author with instructions for completing the selections._
+
+[cols=",,,",options="header",]
+|===
+| |RSA key establishment... |EC Diffie-Hellman key agreement... |Diffie-Hellman key agreement...
+|TLS 1.3 without TLS 1.2 or TLS 1.1 | Shall not select 2+| Shall select at least one   
+|TLS 1.3 with TLS 1.2 or TLS 1.1 |See the following rows 2+|Shall select at least one- see the following rows for additional instructions 
+|TLS 1.2 or TLS 1.1 with support for at least one TLS_RSA_WITH... ciphersuite |Shall select |N/A |N/A
+|TLS 1.2 or TLS 1.1 without support for any TLS_RSA_WITH... ciphersuite |Shall not select |N/A |N/A
+|TLS 1.2 or TLS 1.1 with support for at least one ECDHE ciphersuite |N/A |Shall select |N/A
+|TLS 1.2 or TLS 1.1 without support for TLS1.3 or any ECDHE ciphersuites |N/A |Shall not select |N/A
+|TLS 1.2 & TLS 1.1 with support for at least one DHE ciphersuite |N/A |N/A |Shall select
+|TLS 1.2 & TLS 1.1 without support for TLS 1.3 or any DHE ciphersuites |N/A |N/A |Shall not select
+|===
+
+_N/A indicates the options do not affect whether the selection is selected or not._
+
+_The RSA key size(s) specified in FCS_TLSS_EXT.1.3 are used for RSA key establishment._
+
+_Subsequent versions of this cPP will require support for the Supported Groups extension and prohibit use of legacy DH groups for key establishment._
+
+*FCS_TLSS_EXT.1.4* The TSF shall support [selection: _no session resumption, sessiion resumption based on session IDs according to RFC4346 (TLS1.1) or RFC5246 (TLS1.2), session resumption based on session tickets according to RFC5077 (TLS1.2), session resumption according to RFC8446 (TLS1.3)_].
 
 *_Application Note {counter:appnote_count}_*
 
-_If the TOE does not support session resumption or session tickets, select 'no session resumption or session tickets’. If the TOE supports session resumption based on session IDs according to RFC 4346 (TLS1.1) or RFC 5246 (TLS1.2), select 'session resumption based on session IDs according to RFC 4346 (TLS1.1) or RFC 5246 (TLS1.2)'. If the TOE supports session resumption based on session tickets according to RFC 5077, select 'session resumption based on session tickets according to RFC 5077'._
+_If the TOE doesn't support session resumption or session tickets, select 'no session resumption'. If the TOE supports session resumption based on session IDs according to RFC4346 (TLS1.1) or RFC5246 (TLS1.2), select 'sessiion resumption based on session IDs according to RFC4346 (TLS1.1) or RFC5246 (TLS1.2)'. If the TOE supports session resumption based on session tickets according to RFC5077, select 'session resumption based on session tickets according to RFC5077 (TLS1.2)'. If the TOE supports session resumption according to RFC8446 (TLS1.3), select 'session resumption according to RFC8446 (TLS1.3)'._
+
+*FCS_TLSS_EXT.1.5* The TSF [selection: _provide, do not provide_] the ability of configuring the list of supported ciphersuites as defined in FCS_TLSS_EXT.1.1. 
+
+*_Application Note {counter:appnote_count}_*
+
+_The option 'provide' shall be selected if the TOE allows to configure the list of ciphers as defined in FCS_TLSS_EXT.1.1 (e.g., enabling/disabling of ciphers, ordering, assigning priorities). Otherwise the option 'do not provide' shalled be selected._
+
+*FCS_TLSS_EXT.1.6* The TSF _shall prohibit the use of the following extensions:_
+
+* _Early data extension_
+
+*_Application Note {counter:appnote_count}_*
+
+_The use of the early data extension is prohibited in the configured TOE._
+
+*FCS_TLSS_EXT.1.7* The TSF shall not permit TLSv1.3 connections using an out-of-band provisioned pre-shared key (PSK). Any use of PSKs in TLSv1.3 must use (EC)DHE to provide forward secrecy. 
+
+*_Application Note {counter:appnote_count}_*
+
+_The use of out-of-band provisioned pre-shared keys creates a potential security concern since the entropy used to generate the PSK is outside of the control of the TOE. PSKs are used in TLSv1.3 to provide session resumption; however, in this case, the TSF is responsible for generating appropriately strong keying material. Use of (EC)DHE further enhances security when using PSKs by providing forward secrecy._
+
 
 === Identification and Authentication (FIA)
 
@@ -4145,7 +4202,7 @@ The following actions should be considered for audit if FAU_GEN Security audit d
 . TLS session establishment
 . TLS session termination
 
-*FCS_TLSS_EXT.1 TLS Server Protocol without Mutual Authentication*
+*FCS_TLSS_EXT.1 TLS Server Protocol*
 
 ____
 Hierarchical to: No other components
@@ -4169,19 +4226,37 @@ FIA_X509_EXT.1 X.509 Certificate Validation
 FIA_X509_EXT.2 X.509 Certificate Authentication
 ____
 
-*FCS_TLSS_EXT.1.1* The TSF shall implement [selection: _TLS 1.2 (RFC 5246), TLS 1.1 (RFC 4346)_] and reject all other TLS and SSL versions. The TLS implementation will support the following ciphersuites:
+*FCS_TLSS_EXT.1.1* The TSF shall implement [selection: _TLS 1.3 (RFC 8446), TLS 1.2 (RFC 5246)_] and [selection: _TLS 1.1 (RFC 4346, no additional TLS version)_] and reject all other TLS and SSL versions. The TLS implementation will support the following ciphersuites:
 
-* {blank}
-+
-____
-_[assignment: list of optional ciphersuites and reference to RFC in which each is defined]_ and no other ciphersuites.
-____
+[selection: 
 
-*FCS_TLSS_EXT.1.2* The TSF shall deny connections from clients requesting _SSL 2.0, SSL 3.0, TLS 1.0 and [selection: TLS 1.1, TLS 1.2, none]_.
+* _select supported ciphersuites for TLSv1.1 and/or TLSv1.2 from List 1_
+* _select supported ciphersuites for TLSv1.3 from List 2_
 
-*FCS_TLSS_EXT.1.3* The TSF shall perform key establishment for TLS using [selection: _RSA with key size [selection: 2048 bits, 3072 bits, 4096 bits], Diffie-Hellman parameters with size_ [selection__: 2048 bits, 3072 bits, 4096 bits, 6144 bits, 8192 bits], Diffie-Hellman groups__ [selection: _ffdhe2048, ffdhe3072, ffdhe4096, ffdhe6144, ffdhe8192, no other groups], ECDHE curves [selection: secp256r1, secp384r1, secp521r1] and no other curves_]].
+] and no other ciphersuites. 
 
-*FCS_TLSS_EXT.1.4* The TSF shall support [selection: _no session resumption or session tickets, session resumption based on session IDs according to_ RFC 4346 _(TLS1.1) or_ RFC 5246 _(TLS1.2), session resumption based on session tickets according to_ RFC 5077].
+*FCS_TLSS_EXT.1.2* The TSF shall authenticate itself using X.509 certificate(s) using [selection: _RSA with key size [selection: 2048 bits, 3072 bits, 4096 bits]; ECDSA over NIST curves [selection: secp256r1, secp384r1, secp521r1] and no other curves_].
+
+*FCS_TLSS_EXT.1.3* The TSF shall perform key exchange using: [selection: 
+
+* _RSA key establishment with key size [selection: 2048 bits, 3072 bits, 4096 bits];_
+
+* _EC Diffie-Hellman key agreement over NIST curves [selection: secp256r1, secp384r1, secp521r1] and no other curves;_
+
+* _Diffie-Hellman parameters [selection: of size 2048 bits, of size 3072 bits, of size 4096 bits, of size 6144 bits, of size 8192 bits, ffdhe2048, ffdhe3072, ffdhe4096, ffdhe6144, ffdhe8192]_
+
+].
+
+*FCS_TLSS_EXT.1.4* The TSF shall support [selection: _no session resumption, session resumption based on session IDs according to RFC4346 (TLS1.1) or RFC5246 (TLS1.2), session resumption based on session tickets according to RFC5077 (TLS1.2), session resumption according to RFC8446 (TLS1.3)_].
+
+*FCS_TLSS_EXT.1.5* The TSF [selection: _provide, do not provide_] the ability of configuring the list of supported ciphersuites as defined in FCS_TLSS_EXT.1.1.
+
+*FCS_TLSS_EXT.1.6* The TSF _shall prohibit the use of the following extensions:_
+
+* _Early data extension_
+
+*FCS_TLSS_EXT.1.7* The TSF shall not permit TLSv1.3 connections using an out-of-band provisioned pre-shared key (PSK).  Any use of PSKs in TLSv1.3 must use (EC)DHE to provide forward secrecy.
+
 
 *FCS_TLSS_EXT.2 TLS Server Support for Mutual Authentication*
 

--- a/NDcPP_v2_2e.adoc
+++ b/NDcPP_v2_2e.adoc
@@ -1864,7 +1864,7 @@ If the TOE acts as the server during the claimed DTLS sessions, the ST author sh
 
 *FCS_DTLSC_EXT.2 DTLS Client Support for Mutual Authentication*
 
-*FCS_DTLSC_EXT.2.1* The TSF shall support mutual authentication using X.509v3 certificates.
+*FCS_DTLSC_EXT.2.1* The TSF shall support DTLS communication with mutual authentication of DTLS Clients using X.509v3 certificates.
 
 *_Application Note {counter:appnote_count}_*
 
@@ -1874,7 +1874,7 @@ _The use of X.509v3 certificates for DTLS is addressed in FIA_X509_EXT.2.1. This
 
 *_Application Note {counter:appnote_count}_*
 
-_The Message Authentication Code (MAC) is negotiated during the DTLS handshake phase and is used to protect the integrity of messages received from the sender during DTLS data exchange. If MAC verification fails, the session must be terminated, or the record must be silently discarded._
+_The Message Authentication Code (MAC) is negotiated during the DTLS handshake phase and is used to protect the integrity of messages received from the sender during DTLS data exchange (see 'Handling Invalid Records' in RFC (tbd - current draft for DTLS 1.3 is V38), section 4.5.2 and 4.1.2.7 in RFC 6347(DTLS 1.2)). If MAC verification fails, the session must be terminated, or the record must be silently discarded._
 
 *FCS_DTLSC_EXT.2.3* The TSF shall detect and silently discard replayed messages for:
 
@@ -1883,17 +1883,26 @@ _The Message Authentication Code (MAC) is negotiated during the DTLS handshake p
 
 *_Application Note {counter:appnote_count}_*
 
-_Replay Detection is described in section 4.1.2.6 of DTLS 1.2 (RFC 6347) and section 4.1.2.5 of DTLS 1.0 (RFC 4347). For each received record, the receiver verifies the record contains a sequence number that is within the sliding receive window and does not duplicate the sequence number of any other record received during the session._
+_Replay Detection is described in section 4.5.1 of DTLS 1.3 (RFC tbd, current draft version is V38), 4.1.2.6 of DTLS 1.2 (RFC 6347) and section 4.1.2.5 of DTLS 1.0 (RFC 4347). For each received record, the receiver verifies the record contains a sequence number that is within the sliding receive window and does not duplicate the sequence number of any other record received during the session._
 
 _"Silently Discard" means the TOE discards the packet without responding._
 
 *FCS_DTLSS_EXT.2 DTLS Server Support for Mutual Authentication*
 
-*FCS_DTLSS_EXT.2.1* The TSF shall support mutual authentication of DTLS clients using X.509v3 certificates.
+*FCS_DTLSS_EXT.2.1* The TSF shall support DTLS communication with mutual authentication of DTLS clients using X.509v3 certificates and shall [selection:
+
+* reject the connection if the client does not provide a client certificate at all or the client certificate cannot be successfully validated by the TOE (except for override mechanisms that might be defined in FCS_DTLSS_EXT.2.2) ('hard fail')
+
+* accept the connection even if the client does not provide a client certificate at all, as long as a fall-back authentication is performed using one of the other authentication mechanisms defined in this cPP before any other TSF-mediated action is performed via this channel ('soft fail')
+
+].
+
 
 *_Application Note {counter:appnote_count}_*
 
-_The use of X.509v3 certificates for DTLS is addressed in FIA_X509_EXT.2.1. This requirement adds that this use must include support for client-side certificates for DTLS mutual authentication._
+_The use of X.509v3 certificates for DTLS is addressed in FIA_X509_EXT.2.1. This requirement adds that the client must be capable of presenting a certificate to a DTLS server this use must include support for client-side certificates for DTLS mutual authentication._
+
+_There are different behaviours of the TOE possible for the 'soft fail' option depending on the type of product, use case and actual implementation. It is quite common that in case the server requests the client certificate but the client does not present a certificate, the establishment of the DTLS connection continues (up to the point where the connection is fully established) but fall-back authentication using one of the other authentication mechanisms defined in this cPP is enforced before any other TSF-mediated action can be performed (e.g. transfer of TSF data other than data needed for fall-back authentication; administration of the TOE). It is acceptable to establish the channel without fall-back authentication in case no TSF-mediated action is possible through this channel. For any channel that allows TSF-mediated actions, either successful client authentication through successful validation of the client's X.509 certificate or successful fall-back authentication using one of the other authentication mechanisms defined in this cPP is required._
 
 *FCS_DTLSS_EXT.2.2* When establishing a trusted channel, by default the TSF shall not establish a trusted channel if the client certificate is invalid. The TSF shall also [selection:
 
@@ -1903,6 +1912,10 @@ _The use of X.509v3 certificates for DTLS is addressed in FIA_X509_EXT.2.1. This
 ].
 
 *_Application Note {counter:appnote_count}_*
+
+_The use of X.509v3 certificates for DTLS is addressed in FIA_X509_EXT.2.1. This requirement adds that this use must include support for client-side certificates for DTLS mutual authentication. If the revocation status of a certificate received by the TOE is ambiguous (e.g. ‘unknown’), this should be treated similar to the situation where no connection could be established to the revocation server and the option ‘determine the revocation status’ could be chosen for this._
+
+_The purpose of the explicit selection in the SFR is to prevent the TOE from providing an override mechanism for situations other than specified in the selection (e.g. one or more certificates in the certification path have been revoked and this status is known to the TOE)._
 
 _‘Revocation status’ refers to an OCSP or CRL response that indicates the presented certificate is invalid. Inability to make a connection to determine validity shall be handled as specified in FIA_X509_EXT.2.2._
 
@@ -1915,6 +1928,37 @@ _If DTLS is selected in FPT_ITT, then certificate validity is tested in accordan
 *_Application Note {counter:appnote_count}_*
 
 _The client identifier may be in the Subject field or the Subject Alternative Name extension of the certificate. The expected identifier may either be configured, may be compared to the Domain Name, IP address, username, or email address used by the peer, or may be passed to a directory server for comparison._
+
+*FCS_DTLSS_EXT.2.4* The TSF shall [selection:
+
+* _present a DTLS1.0 Certificate Request message containing the following ClientCertificateTypes: [selection:_
+** rsa_sign,
+** ecdsa_sign,
+** ] and no other ClientCertificateTypes;
+* present a [selection: DTLSv1.2, DTLSv1.3] Certificate Request message containing the following algorithms: [selection:
+** rsa_pkcs1 with sha256(0x0401),
+** rsa_pkcs1 with sha384(0x0501),
+** rsa_pkcs1 with sha512(0x0601),
+** ecdsa_secp256r1 with sha256(0x0403),
+** ecdsa_secp384r1 with sha384(0x0503),
+** ecdsa_secp521r1 with sha512(0x0603),
+** rsa_pss_rsae with sha256(0x0804),
+** rsa_pss_rsae with sha384(0x0805),
+** rsa_pss_rsae with sha512(0x0806),
+** rsa_pss_pss with sha256(0x0809),
+** rsa_pss_pss with sha384(0x080a),
+** rsa_pss_pss with sha512(0x080b)
+** ] and no other algorithms;
+
+].
+
+*_Application Note {counter:appnote_count}_*
+
+_The selected ClientCertificateTypes and algorithms must be consistent with FCS_COP.1/SigGen and FCS_COP.1/Hash._
+
+_The DTLS 1.2 Certificate Request message includes the algorithms as a list of  SignatureAndHashAlgorithms in the supported signature algorithms list. The signature algorithm is also specified in the certificate_types list._
+
+_The DTLS 1.3 Certificate Request message includes the algorithms as a list of  SignatureSchemes in the signature_algorithms extension._
 
 =====  FCS_TLSC_EXT & FCS_TLSS_EXT TLS Protocol
 
@@ -1929,6 +1973,18 @@ A TOE may act as the client, the server, or both in TLS sessions. The requiremen
 *_Application Note {counter:appnote_count}_*
 
 _The use of X.509v3 certificates for TLS is addressed in FIA_X509_EXT.2.1. This requirement adds that the client must be capable of presenting a certificate to a TLS server for TLS mutual authentication._
+
+*FCS_TLSC_EXT.3 TLS Client Support for renegotiation (TLSv1.1/v1.2 only)*
+
+*FCS_TLSC_EXT.3.1* The product shall support secure renegotiation through use of the “renegotiation_info” TLS extension in accordance with RFC 5746.
+
+*_Application Note {counter:appnote_count}_*
+
+_This component may only be claimed for TLSv1.1 and TLSv1.2 but not TLSv1.3._
+
+_RFC 5746 defines an extension to TLS that binds renegotiation handshakes to the cryptography in the original handshake._
+
+_Per RFC 5746, the client may present either the "renegotiation_info" extension or the signaling cipher suite value TLS_EMPTY_RENEGOTIATION_INFO_SCSV in the initial ClientHello message to indicate support for renegotiation. (A signaling cipher suite value (SCSV) is presented as a cipher suite, but its only purpose is to provide other information and not to advertise support for a cipher suite.) The TLS_EMPTY_RENEGOTIATION_INFO_SCSV signaling cipher suite value exists as an alternative to presenting the "renegotation_info" extension so that TLS server implementations that immediately terminate the connection when they encounter any extension they do not understand can still proceed with a connection. The client may still choose to reject the connection later, if it insists upon renegotiation support and the server does not support it. In any case, RFC 5746 states that during any renegotiation the "renegotiation_info" extension must be presented by the peer initiating renegotiation, and so the client must support use of this extension._
 
 *FCS_TLSS_EXT.2 TLS Server Support for Mutual Authentication*
 
@@ -1964,6 +2020,18 @@ _If TLS is selected in FPT_ITT, then certificate validity is tested in accordanc
 _If the identifier is not a FQDN, then the TSS shall describe how the identifier is parsed from the certificate and matched._
 
 _The client identifier may be in the Subject field or the Subject Alternative Name extension of the certificate. The expected identifier may either be configured, may be compared to the FQDN, IP address, username, or email address used by the client, or may be passed to a directory server for comparison._
+
+*FCS_TLSS_EXT.3 TLS Server Support for renegotiation (TLSv1.1/v1.2 only)*
+
+*FCS_TLSS_EXT.3.1* The product shall support the "renegotiation_info" TLS extension in accordance with RFC 5746.
+
+*FCS_TLSS_EXT.3.2* The product shall include the renegotiation_info extension in ServerHello messages.
+
+*_Application Note {counter:appnote_count}_*
+
+_This component may only be claimed for TLSv1.1 and TLSv1.2 but not TLSv1.3._
+
+_RFC 5746 defines an extension to TLS that binds renegotiation handshakes to the cryptography in the original handshake._
 
 [appendix]
 == Selection-Based Requirements
@@ -2085,24 +2153,20 @@ To ensure audit requirements are properly met, a DTLS receiver may need to monit
 
 If the TOE acts as the server during the claimed DTLS sessions, the ST author should claim the corresponding FCS_DTLSS_EXT requirements. In this case the TOE needs to claim at least the FCS_DTLSS_EXT.1 requirements in chap. B.3.1.1 (no support for mutual authentication). If the TOE acts as DTLS server and in addition also supports mutual authentication, the FCS_DTLSS_EXT.2 requirements in chap. A.7.1.1 need to be claimed in addition. If the TOE acts as both a client and server during the claimed DTLS sessions, the ST author should claim the corresponding FCS_DTLSC_EXT and FCS_DTLSS_EXT requirements.
 
-*FCS_DTLSC_EXT.1 DTLS Client Protocol Without Mutual Authentication*
+*FCS_DTLSC_EXT.1 DTLS Client Protocol*
 
-*FCS_DTLSC_EXT.1.1* The TSF shall implement [selection: _DTLS 1.2 (RFC 6347), DTLS 1.0 (RFC 4347)_] supporting the following ciphersuites:
+*FCS_DTLSC_EXT.1.1* The TSF shall implement [selection: _DTLS 1.3 (RFC tbd), DTLS 1.2 (RFC 6347)] and [selection: DTLS 1.0 (RFC 4347), no additional DTLS version_] supporting the following ciphersuites:
 
 * [selection:
-** [.underline]#_select supported ciphersuites from List 1] and no other ciphersuites_.#
-
-].
+** [.underline]#_select supported ciphersuites for DTLS 1.0 and 1.2 from List 1]_#
+** [.underline]#_select supported ciphersuites for DTLS 1.3 from List 2
+] and no other ciphersuites_.#
 
 *_Application Note {counter:appnote_count}_*
 
-_The ciphersuites to be tested in the evaluated configuration are limited by this requirement and must be selected from the ciphersuites defined in List 1, chap..B.3.1.6. The ST author should select the ciphersuites that are supported. Even though RFC 5246 and RFC 6347 mandate implementation of specific ciphers, there is no requirement to implement TLS_RSA_WITH_AES_128_CBC_SHA in order to claim conformance to this cPP._
+_The ciphersuites to be tested in the evaluated configuration are limited by this requirement requirement and shall be selected from the ciphersuites defined in List 1 (DTLS 1.0/1.2) and List 2 (DTLS 1.3), respectively (both in chap. B.3.1.6). The ST author should select the ciphersuites that are supported. Even though RFC 5246 and RFC 6347 mandate implementation of specific ciphers, this cPP deprecates use of SHA-1. Support for TLS_RSA_WITH_AES_128_CBC_SHA is not claimed in order to claim conformance to this cPP._
 
 _These requirements will be revisited as new DTLS versions are standardized by the IETF._
-
-_In a future version of this cPP DTLS v1.2 will be required for all TOEs._
-
-_FCS_DTLSC_EXT.1 should only be used if the TOE transmits application-layer data to an external entity using a trusted channel provided by DTLS without receiving application data that needs to be protected._
 
 *FCS_DTLSC_EXT.1.2* The TSF shall verify that the presented identifier matches [selection: _the reference identifier per RFC 6125 section 6, IPv4 address in CN or SAN, IPv6 address in the CN or SAN, IPv4 address in SAN, IPv6 address in the SAN, the identifier per RFC 5280 Appendix A using [selection: id-at-commonName, id-at-countryName, id-at-dnQualifier, id-at-generationQualifier, id-at-givenName, id-at-initials, id-at-localityName, id-at-name, id-at-organizationalUnitName, id-at-organizationName, id-at-pseudonym, id-at-serialNumber, id-at-stateOrProvinceName, id-at-surname, id-at-title] and no other attribute types_].
 
@@ -2118,10 +2182,10 @@ _The preferred method for verification is the Subject Alternative Name using DNS
 
 _Finally, the client should avoid constructing reference identifiers using wildcards. However, if the presented identifiers include wildcards and the TOE supports wildcard, the client must follow the best practices regarding matching; these best practices are captured in the evaluation activity. The exception being, the use of wildcards is not supported when using IP address as the reference identifier._
 
-*FCS_DTLSC_EXT.1.3* When establishing a trusted channel, by default the TSF shall not establish a trusted channel if the server certificate is invalid. The TSF shall also [selection:
+*FCS_DTLSC_EXT.1.3* The TSF shall not establish a trusted channel if the server certificate is invalid [selection:
 
-* _Not implement any administrator override mechanism_
-* _require administrator authorization to establish the connection if the TSF fails to [selection: match the reference identifier, validate certificate path, validate expiration date, determine the revocation status] of the presented server certificate_
+* _without any administrator override mechanism._
+* _except with the following administrator override:   If the TSF fails to [selection: match the reference identifier, validate certificate path, validate expiration date, determine the revocation status] the TSF shall allow the administrator to provide override authorization to establish the connection on a per certificate basis._
 
 ].
 
@@ -2129,21 +2193,107 @@ _Finally, the client should avoid constructing reference identifiers using wildc
 
 _‘Revocation status’ refers to an OCSP or CRL response that indicates the presented certificate is invalid. Inability to make a connection to determine validity shall be handled as specified in FIA_X509_EXT.2.2. If the revocation status of a certificate received by the TOE is ambiguous (e.g. ‘unknown’), this should be treated similar to the situation where no connection could be established to the revocation server and the option ‘determine the revocation status’ could be chosen for this._
 
-_The purpose of the explicit selection in the SFR is to prevent the TOE from providing an override mechanism for situations other than specified in the selection (e.g. one or more certificates in the certification path have been revoked and this status is known to the TOE)._
+_The purpose of the explicit selection in the SFR is to prevent the TOE to provide an override authorization for situations other than specified in the selection (e.g. one or more certificates in the certification path have been revoked and this status is known to the TOE).  Override may be sought or granted at any time, though this typically occurs when an invalid certificate is presented during connection setup.  Override decisions may be stored and then consulted later, to permit connections using these otherwise-invalid certificates to establish trusted channels without user or administrator action._
 
 _If DTLS is selected in FTP_ITC then certificate validity is tested in accordance with testing performed for FIA_X509_EXT.1/Rev._
 
 _If DTLS is selected in FPT_ITT, then certificate validity is tested in accordance with testing performed for FIA_X509_EXT.1/ITT._
 
-*FCS_DTLSC_EXT.1.4* The TSF shall [selection: _not present the_ _Supported Elliptic Curves/Supported Groups Extension, present the Supported Elliptic Curves/Supported Groups Extension with the following curves/groups:_ [selection: _secp256r1, secp384r1, secp521r1, ffdhe2048, ffdhe3072, ffdhe4096, ffdhe6144, ffdhe8192_] _and no other curves/groups_] in the Client Hello.
+*FCS_DTLSC_EXT.1.4* The TSF shall [selection: _not present the Supported Groups Extension, present the Supported Groups Extension with the following curves/groups:_ [selection: _secp256r1, secp384r1, secp521r1, ffdhe2048, ffdhe3072, ffdhe4096, ffdhe6144, ffdhe8192_] _and no other curves/groups_] in the Client Hello.
 
 *_Application Note {counter:appnote_count}_*
 
-_If ciphersuites with elliptic curves were selected in FCS_DTLSC_EXT.1.1, a selection of one or more curves is required. If no ciphersuites with elliptic curves were selected in FCS_DTLSC_EXT.1.1, then “not present the Supported Elliptic Curves Extension” should be selected._
+_The “Supported Elliptic Curves” extension was renamed to “Supported Groups” by RFC 7919; however, both terms refer to the same extension._
 
-_This requirement limits the elliptic curves allowed for authentication and key agreement to the NIST curves from FCS_COP.1/SigGen and FCS_CKM.1 and FCS_CKM.2. This extension is required for clients supporting Elliptic Curve ciphersuites._
+_The following table provides the ST author with instructions for completing the selections._
 
-_If ciphersuites with DHE key agreement were selected FCS_DTLSC_EXT.1.1 and the TOE supports TLS FFC groups (e.g. ffdhe2048), this extension is required. This extension is not required if the TOE only supports non-TLS FFC groups (e.g. Group 14)._
+
+[cols="1,1,1"]
+|===
+| |_not present the Supported Groups Extension_|_present the Supported Groups Extension_
+|_DTLS 1.3 with or without DTLS 1.2 or DTLS 1.0_|_Shall not select_|_Shall select with any secp curves or any ffdhe groups – If DTLS 1.2 or DTLS 1.0 is supported, see the following rows for additional instructions._
+|_DTLS 1.2 or DTLS 1.0 with support for at least one ECDHE ciphersuite_|_Shall not select_|_Shall select – at least one secp curve shall be selected_
+|_DTLS 1.2 or DTLS 1.0 with support for at least one DHE ciphersuite_|_May select_ +
+
+_This extension is not required, because older TLS implementations did not negotiate FFC parameters (e.g. Group 14)._|_May select – at least one ffdhe group shall be selected_
+|===
+
+Subsequent versions of this cPP will require support for the Supported Groups extension and prohibit use of legacy DH groups for key establishment.
+
+*FCS_DTLSC_EXT.1.5* The TSF shall [selection:
+
+* _present the signature_algorithms extension with support for the following algorithms: +
+[selection:_
+
+** _rsa_pkcs1 with sha256(0x0401),_
+** _rsa_pkcs1with sha384(0x0501),_
+** _rsa_pkcs1 with sha512(0x0601),_
+** _ecdsa_secp256r1 with sha256(0x0403),_
+** _ecdsa_secp384r1 with sha384(0x0503),_
+** _ecdsa_secp521r1 with sha512(0x0603),_
+** _rsa_pss_rsae with sha256(0x0804),_
+** _rsa_pss_rsae with sha384(0x0805),_
+** _rsa_pss_rsae with sha512(0x0806),_
+** _rsa_pss_pss with sha256(0x0809),_
+** _rsa_pss_pss with sha384(0x080a),_
+** _rsa_pss_pss with sha512(0x080b)_
+** ] and no other algorithms;
+
+* _present the signature_algorithms_cert extension with the following Signature Schemes:_ +
+_[selection:_
+
+** _rsa_pkcs1 with sha256(0x0401),_
+** _rsa_pkcs1with sha384(0x0501),_
+** _rsa_pkcs1 with sha512(0x0601),_
+** _ecdsa_secp256r1 with sha256(0x0403),_
+** _ecdsa_secp384r1 with sha384(0x0503),_
+** _ecdsa_secp521r1 with sha512(0x0603),_
+** _rsa_pss_rsae with sha256(0x0804),_
+** _rsa_pss_rsae with sha384(0x0805),_
+** _rsa_pss_rsae with sha512(0x0806),_
+** _rsa_pss_pss with sha256(0x0809),_
+** _rsa_pss_pss with sha384(0x080a),_
+** _rsa_pss_pss with sha512(0x080b)_
+** _] and no other SignatureSchemes;_
+
+_]._
+
+*_Application Note {counter:appnote_count}_*
+
+_The selected algorithms and SignatureSchemes must be consistent with FCS_COP.1/SigGen and FCS_COP.1/Hash._
+
+_DTLS 1.2 and DTLS 1.3 define different signature_algorithms extension formats. DTLS 1.2 specifies the HashAlgorithm and SignatureAlgorithm independently while DTLS 1.3 specifies SignatureSchemes. This element intentionally limits the signature and hash algorithms that may be selected_
+
+_The following table provides the ST author with instructions for completing the selections._
+
+[cols="1,1,1"]
+|===
+| |_present the signature_algorithms extension_|_present the signature_algorithms_cert extension_
+|_DTLS 1.3_|_Shall select_|_May select_
+|_DTLS 1.2 without DTLS 1.3_|_May select_|_Shall not select_
+|===
+
+
+*FCS_DTLSC_EXT.1.6* The TSF [selection: _provides, does not provide_] the ability to configure the list of supported ciphersuites as defined in FCS_DTLSC_EXT.1.1.
+
+*_Application Note {counter:appnote_count}_*
+
+_The option 'provides' shall be selected if the TOE provides the ability to configure the list of ciphers as defined in FCS_DTLSC_EXT.1.1 (e.g. enabling/disabling of ciphers, ordering, assigning priorities). Otherwise the option 'does not provide' shall be selected._
+
+*FCS_DTLSC_EXT.1.7* The TSF _shall prohibit the use of the following extensions:
+
+* Early data extension
+* post-handshake client authentication according to RFC(tbd- current draft for DTLS 1.3 is V38), section 5.7.3._
+
+*_Application Note {counter:appnote_count}_*
+
+_The use of the early data extension and the post-handshake client authentication is prohibited in the configured TOE. Prohibiting post-handshake client authentication might be dropped in a future version of NDcPP_
+
+*FCS_DTLSC_EXT.1.8* The TSF shall not permit DTLS 1.3 connections using an out-of-band provisioned pre-shared key (PSK).  Any use of PSKs in DTLS 1.3 must use (EC)DHE to provide forward secrecy.
+
+*_Application Note {counter:appnote_count}_*
+
+_The use of out-of-band provisioned pre-shared keys creates a potential security concern since the entropy used to generate the PSK is outside of the control of the TOE. PSKs are used in DTLS 1.3 to provide session resumption; however, in this case, the TSF is responsible for generating appropriately strong keying material.  Use of (EC)DHE further enhances security when using PSKs by providing forward secrecy._
 
 *FCS_DTLSS_EXT.1 DTLS Server Protocol Without Mutual Authentication*
 
@@ -3123,21 +3273,69 @@ FIA_X509_EXT.1 X.509 Certificate Validation
 FIA_X509_EXT.2 X.509 Certificate Authentication
 ____
 
-*FCS_DTLSC_EXT.1.1* The TSF shall implement [selection: _DTLS 1.2 (RFC 6347), DTLS 1.0 (RFC 4347)_] supporting the following ciphersuites:
+*FCS_DTLSC_EXT.1.1* The TSF shall implement [selection: _DTLS 1.3 (RFC tbd), DTLS 1.2 (RFC 6347)] and [selection: DTLS 1.0 (RFC 4347), no additional DTLS version_] supporting the following ciphersuites:
 
-* _[assignment: List of optional ciphersuites and reference to RFC in which each is defined]._
+* [selection:
+** [.underline]#_select supported ciphersuites for DTLS 1.0 and 1.2 from List 1]_#
+** [.underline]#_select supported ciphersuites for DTLS 1.3 from List 2] and no other ciphersuites_.#
 
 *FCS_DTLSC_EXT.1.2* The TSF shall verify that the presented identifier matches [selection: _the reference identifier per RFC 6125 section 6, IPv4 address in CN or SAN, IPv6 address in the CN or SAN, IPv4 address in SAN, IPv6 address in the SAN, the identifier per RFC 5280 Appendix A using [selection: id-at-commonName, id-at-countryName, id-at-dnQualifier, id-at-generationQualifier, id-at-givenName, id-at-initials, id-at-localityName, id-at-name, id-at-organizationalUnitName, id-at-organizationName, id-at-pseudonym, id-at-serialNumber, id-at-stateOrProvinceName, id-at-surname, id-at-title] and no other attribute types_].
 
-*FCS_DTLSC_EXT.1.3* When establishing a trusted channel, by default the TSF shall not establish a trusted channel if the server certificate is invalid. The TSF shall also [selection:
+*FCS_DTLSC_EXT.1.3* The TSF shall not establish a trusted channel if the server certificate is invalid [selection:
 
-* _Not implement any administrator override mechanism_
-* _require administrator authorization to establish the connection if the TSF fails to [selection: match the reference identifier, validate certificate path, validate expiration date, determine the revocation status] of the presented server certificate_
+* _without any administrator override mechanism._
+* _except with the following administrator override:   If the TSF fails to [selection: match the reference identifier, validate certificate path, validate expiration date, determine the revocation status] the TSF shall allow the administrator to provide override authorization to establish the connection on a per certificate basis._
 
 ].
 
-*FCS_DTLSC_EXT.1.4* The TSF shall [selection: _not present the Supported Elliptic Curves/Supported Groups Extension, present the Supported Elliptic Curves/Supported Groups Extension with the following curves/groups: [selection: secp256r1, secp384r1, secp521r1, ffdhe2048, ffdhe3072, ffdhe4096, ffdhe6144, ffdhe8192] and no other curves/groups_] in the Client Hello.
+*FCS_DTLSC_EXT.1.4* The TSF shall [selection: _not present the Supported Groups Extension, present the Supported Groups Extension with the following curves/groups:_ [selection: _secp256r1, secp384r1, secp521r1, ffdhe2048, ffdhe3072, ffdhe4096, ffdhe6144, ffdhe8192_] _and no other curves/groups_] in the Client Hello.
 
+*FCS_DTLSC_EXT.1.5* The TSF shall [selection:
+
+* _present the signature_algorithms extension with support for the following algorithms: +
+[selection:_
+
+** _rsa_pkcs1 with sha256(0x0401),_
+** _rsa_pkcs1with sha384(0x0501),_
+** _rsa_pkcs1 with sha512(0x0601),_
+** _ecdsa_secp256r1 with sha256(0x0403),_
+** _ecdsa_secp384r1 with sha384(0x0503),_
+** _ecdsa_secp521r1 with sha512(0x0603),_
+** _rsa_pss_rsae with sha256(0x0804),_
+** _rsa_pss_rsae with sha384(0x0805),_
+** _rsa_pss_rsae with sha512(0x0806),_
+** _rsa_pss_pss with sha256(0x0809),_
+** _rsa_pss_pss with sha384(0x080a),_
+** _rsa_pss_pss with sha512(0x080b)_
+** ] and no other algorithms;
+
+* _present the signature_algorithms_cert extension with the following Signature Schemes:_ +
+_[selection:_
+
+** _rsa_pkcs1 with sha256(0x0401),_
+** _rsa_pkcs1with sha384(0x0501),_
+** _rsa_pkcs1 with sha512(0x0601),_
+** _ecdsa_secp256r1 with sha256(0x0403),_
+** _ecdsa_secp384r1 with sha384(0x0503),_
+** _ecdsa_secp521r1 with sha512(0x0603),_
+** _rsa_pss_rsae with sha256(0x0804),_
+** _rsa_pss_rsae with sha384(0x0805),_
+** _rsa_pss_rsae with sha512(0x0806),_
+** _rsa_pss_pss with sha256(0x0809),_
+** _rsa_pss_pss with sha384(0x080a),_
+** _rsa_pss_pss with sha512(0x080b)_
+** _] and no other SignatureSchemes;_
+
+_]._
+
+*FCS_DTLSC_EXT.1.6* The TSF [selection: _provides, does not provide_] the ability to configure the list of supported ciphersuites as defined in FCS_DTLSC_EXT.1.1.
+
+*FCS_DTLSC_EXT.1.7* The TSF shall prohibit the use of the following extensions:
+
+* Early data extension
+* post-handshake client authentication according to RFC(tbd- current draft for DTLS 1.3 is V38), section 5.7.3.
+
+*FCS_DTLSC_EXT.1.8* The TSF shall not permit DTLS 1.3 connections using an out-of-band provisioned pre-shared key (PSK).  Any use of PSKs in DTLS 1.3 must use (EC)DHE to provide forward secrecy.
 ____
 *FCS_DTLSC_EXT.2 DTLS Client Support for Mutual Authentication*
 
@@ -3721,6 +3919,34 @@ ____
 
 *FCS_TLSC_EXT.2.1* The TSF shall support TLS communication with mutual authentication using X.509v3 certificates.
 
+*FCS_TLSC_EXT.3 TLS Client Support for renegotiation (TLSv1.1/v1.2 only)*
+
+____
+Hierarchical to: No other components
+
+Dependencies: FCS_CKM.1Cryptographic Key Generation
+
+FCS_CKM.2 Cryptographic Key Establishment
+
+FCS_COP.1/DataEncryption Cryptographic operation (AES Data encryption/decryption)
+
+FCS_COP.1/SigGen Cryptographic operation (Signature Generation and Verification)
+
+FCS_COP.1/Hash Cryptographic operation (Hash Algorithm)
+
+FCS_COP.1/KeyedHash Cryptographic operation (Keyed Hash Algorithm)
+
+FCS_RBG_EXT.1 Random Bit Generation
+
+FCS_TLSC_EXT.1 TLS Client Protocol
+
+FIA_X509_EXT.1 X.509 Certificate Validation
+
+FIA_X509_EXT.2 X.509 Certificate Authentication
+____
+
+*FCS_TLSC_EXT.3.1* The product shall support secure renegotiation through use of the “renegotiation_info” TLS extension in accordance with RFC 5746.
+
 =====  FCS_TLSS_EXT TLS Server Protocol
 
 *Family Behaviour*
@@ -3823,6 +4049,35 @@ ____
 ].
 
 *FCS_TLSS_EXT.2.3* The TSF shall not establish a trusted channel if the identifier contained in a certificate does not match an expected identifier for the client. If the identifier is a Fully Qualified Domain Name (FQDN), then the TSF shall match the identifiers according to RFC 6125, otherwise the TSF shall parse the identifier from the certificate and match the identifier against the expected identifier of the client as described in the TSS.
+
+*FCS_TLSS_EXT.3 TLS Server Support for renegotiation (TLSv1.1/v1.2 only)*
+____
+Hierarchical to: No other components
+
+Dependencies: FCS_CKM.1 Cryptographic Key Generation
+
+FCS_CKM.2 Cryptographic Key Establishment
+
+FCS_COP.1/DataEncryption Cryptographic operation (AES Data encryption/decryption)
+
+FCS_COP.1/SigGen Cryptographic operation (Signature Generation and Verification)
+
+FCS_COP.1/Hash Cryptographic operation (Hash Algorithm)
+
+FCS_COP.1/KeyedHash Cryptographic operation (Keyed Hash Algorithm)
+
+FCS_RBG_EXT.1 Random Bit Generation
+
+FCS_TLSS_EXT.1 TLS Server Protocol
+
+FIA_X509_EXT.1 X.509 Certificate Validation
+
+FIA_X509_EXT.2 X.509 Certificate Authentication
+____
+
+*FCS_TLSS_EXT.3.1* The product shall support the "renegotiation_info" TLS extension in accordance with RFC 5746.
+
+*FCS_TLSS_EXT.3.2* The product shall include the renegotiation_info extension in ServerHello messages.
 
 === Identification and Authentication (FIA)
 

--- a/NDcPP_v2_2e.adoc
+++ b/NDcPP_v2_2e.adoc
@@ -2057,17 +2057,15 @@ _The TLS 1.2 Certificate Request message includes the algorithms as a list of  S
 
 _The TLS 1.3 Certificate Request message includes the algorithms as a list of SignatureSchemes in the signature_algorithms extension._
 
-*FCS_TLSS_EXT.3 TLS Server Support for renegotiation (TLSv1.1/v1.2 only)*
+*FCS_TLSS_EXT.3 TLS Server Support for secure renegotiation (TLSv1.1/v1.2 only)*
 
-*FCS_TLSS_EXT.3.1* The product shall support the "renegotiation_info" TLS extension in accordance with RFC 5746.
-
-*FCS_TLSS_EXT.3.2* The product shall include the renegotiation_info extension in ServerHello messages.
+*FCS_TLSS_EXT.3.1* The product shall support secure renegotiation in accordance with RFC 5746 by always including the "renegotiation_info" extension in ServerHello messages.
 
 *_Application Note {counter:appnote_count}_*
 
 _This component may only be claimed for TLSv1.1 and TLSv1.2 but not TLSv1.3._
 
-_RFC 5746 defines an extension to TLS that binds renegotiation handshakes to the cryptography in the original handshake.
+_RFC 5746 defines an extension to TLS that binds renegotiation handshakes to the cryptography in the original handshake, in order to prevent a certain man-in-the-middle attack where the attacker establishes a TLS session with a server, injecting content of their choice, before splicing in a new TLS connection from the client.  The server treats the client's initial TLS handshake as a renegotiation and thus believes that the initial data transmitted by the attacker is from the same entity as the subsequent client data.
 
 [appendix]
 == Selection-Based Requirements
@@ -4394,7 +4392,7 @@ ____
 ** _] and no other algorithms;_ +
 _]._
 
-*FCS_TLSS_EXT.3 TLS Server Support for renegotiation (TLSv1.1/v1.2 only)*
+*FCS_TLSS_EXT.3 TLS Server Support for secure renegotiation (TLSv1.1/v1.2 only)*
 ____
 Hierarchical to: No other components
 
@@ -4419,9 +4417,7 @@ FIA_X509_EXT.1 X.509 Certificate Validation
 FIA_X509_EXT.2 X.509 Certificate Authentication
 ____
 
-*FCS_TLSS_EXT.3.1* The product shall support the "renegotiation_info" TLS extension in accordance with RFC 5746.
-
-*FCS_TLSS_EXT.3.2* The product shall include the renegotiation_info extension in ServerHello messages.
+*FCS_TLSS_EXT.3.1* The product shall support secure renegotiation in accordance with RFC 5746 by always including the "renegotiation_info" extension in ServerHello messages.
 
 
 === Identification and Authentication (FIA)

--- a/NDcPP_v2_2e.adoc
+++ b/NDcPP_v2_2e.adoc
@@ -2775,17 +2775,21 @@ The following list contains all DTLS-/TLS-related ciphersuites supported by this
 
 [.underline]#List 1: List of supported TLS-related ciphersuites#
 
-*FCS_TLSC_EXT.1 TLS Client Protocol Without Mutual Authentication*
+*FCS_TLSC_EXT.1 TLS Client Protocol*
 
-*FCS_TLSC_EXT.1.1* The TSF shall implement [selection: _TLS 1.2 (RFC 5246), TLS 1.1 (RFC 4346)_] and reject all other TLS and SSL versions. The TLS implementation will support the following ciphersuites:
+*FCS_TLSC_EXT.1.1* The TSF shall implement [selection: _TLS 1.3 (RFC 8446), TLS 1.2 (RFC 5246)_] and [selection:  _TLS 1.1 (RFC 4346), no additional TLS version_] and reject all other TLS and SSL versions. The TLS implementation will support the following ciphersuites:
 
 [selection:
 
-[.underline]#_select supported ciphersuites from List 1_] _and no other ciphersuites_#.
+* [.underline]#_select supported ciphersuites for TLSv1.1 and/or TLSv1.2 from List 1_#
+
+* [.underline]#_select supported ciphersuites for TLSv1.3 from List 2_#
+
+] _and no other ciphersuites_.
 
 *_Application Note {counter:appnote_count}_*
 
-_The ciphersuites to be tested in the evaluated configuration are limited by this requirement and must be selected from the ciphersuites defined in List 1. The ST author should select the ciphersuites that are supported. Even though RFC 5246 mandates implementation of specific ciphers, there is no requirement to implement TLS_RSA_WITH_AES_128_CBC_SHA in order to claim conformance to this cPP._
+_The ciphersuites to be tested in the evaluated configuration are limited by this requirement and must be selected from the ciphersuites defined in List 1 (TLSv1.1/v1.2) and List 2 (TLSv1.3), respectively. The ST author should select the ciphersuites that are supported. Even though RFC 5246 mandates implementation of specific ciphers for TLSv1.2 this cPP depreciates use of SHA-1. Support for TLS_RSA_WITH_AES_128_CBC_SHA is not claimed in order to claim conformance to this cPP._
 
 _These requirements will be revisited as new TLS versions are standardized by the IETF._
 
@@ -2794,7 +2798,6 @@ _In a future version of this cPP TLS v1.2 will be required for all TOEs._
 *FCS_TLSC_EXT.1.2* The TSF shall verify that the presented identifier matches [selection: _the reference identifier per RFC 6125 section 6[.underline]##,## IPv4 address in CN or SAN, IPv6 address in the CN or SAN, IPv4 address in SAN, IPv6 address in the SAN, the identifier per RFC 5280 Appendix A using [selection: id-at-commonName, id-at-countryName, id-at-dnQualifier, id-at-generationQualifier, id-at-givenName, id-at-initials, id-at-localityName, id-at-name, id-at-organizationalUnitName, id-at-organizationName, id-at-pseudonym, id-at-serialNumber, id-at-stateOrProvinceName, id-at-surname, id-at-title] and no other attribute types_].
 
 *_Application Note {counter:appnote_count}_*
-
 
 Where TLS is used for connections to/from non-TOE entities (relevant to FTP_ITC and FTP_TRP), the ST author shall select RFC 6125. For distributed TOEs (TLS connections relevant to FPT_ITT), the ST author may select either RFC 6125 or RFC 5280. If RFC 5280 is selected, the selection is completed by listing the AttributeType (e.g. ‘id-at-serialNumber’) as defined in RFC 5280 Appendix A. The selection should only list those attributes that are significant (i.e. those which are used by the client for reference identifier matching), though the Subject field (DN) may contain other attribute types that are not significant for the purpose of reference identifier matching. In the TSS the ST author describes which attribute type, or combination of attributes types, are used by the client to match the presented identifier with the configured identifier. The ST author selects “_the reference identifier per RFC 6125 section 6” for TOEs that support FQDN, SRV, and URI identifiers._
 
@@ -2806,36 +2809,116 @@ _The preferred method for verification is the Subject Alternative Name using DNS
 
 Finally, the client should avoid constructing reference identifiers using wildcards. However, if the presented identifiers include wildcards and the TOE supports wildcard, the client must follow the best practices regarding matching; these best practices are captured in the evaluation activity. The exception being, the use of wildcards is not supported when using IP address as the reference identifier
 
-*FCS_TLSC_EXT.1.3* When establishing a trusted channel, by default the TSF shall not establish a trusted channel if the server certificate is invalid. The TSF shall also [selection:
+*FCS_TLSC_EXT.1.3* The TSF shall not establish a trusted channel if the server certificate is invalid [selection:
 
-* _Not implement any administrator override mechanism_
-* _require administrator authorization to establish the connection if the TSF fails to_ [selection: _match the reference identifier, validate certificate path, validate expiration date, determine the revocation status] of the presented server certificate_
+* _without any administrator override mechanism._
+* _except with the following administrator override:   If the TSF fails to [selection: match the reference identifier, validate certificate path, validate expiration date, determine the revocation status] the TSF shall allow the administrator to provide override authorization to establish the connection on a per certificate basis._
 
 ].
 
 *_Application Note {counter:appnote_count}_*
 
+_‘Revocation status’ refers to an OCSP or CRL response that indicates the presented certificate is invalid. Inability to make a connection to determine validity shall be handled as specified in FIA_X509_EXT.2.2. If the revocation status of a certificate received by the TOE is ambiguous (e.g. ‘unknown’), this should be treated similar to the situation where no connection could be established to the revocation server and the option ‘determine the revocation status’ could be chosen for this._
 
-‘Revocation status’ refers to an OCSP or CRL response that indicates the presented certificate is invalid. Inability to make a connection to determine validity shall be handled as specified in FIA_X509_EXT.2.2. If the revocation status of a certificate received by the TOE is ambiguous (e.g. ‘unknown’), this should be treated similar to the situation where no connection could be established to the revocation server and the option ‘determine the revocation status’ could be chosen for this.
+_The purpose of the explicit selection in the SFR is to prevent the TOE providing an override authorization for situations other than specified in the selection (e.g. one or more certificates in the certification path have been revoked and this status is known to the TOE). Override may be sought or granted at any time, though this typically occurs when an invalid certificate is presented during connection setup.  Override decisions may be stored and then consulted later, to permit connections_ _using these otherwise-invalid certificates to establish trusted channels without user or administrator action._
 
-The purpose of the explicit selection in the SFR is to prevent the TOE providing an override mechanism for situations other than specified in the selection (e.g. one or more certificates in the certification path have been revoked and this status is known to the TOE).
+_If TLS is selected in FTP_ITC, then certificate validity is tested in accordance with testing performed for FIA_X509_EXT.1/Rev._
 
-If TLS is selected in FTP_ITC, then certificate validity is tested in accordance with testing performed for FIA_X509_EXT.1/Rev.
+_If TLS is selected in FPT_ITT, then certificate validity is tested in accordance with testing performed for FIA_X509_EXT.1/ITT._
 
-If TLS is selected in FPT_ITT, then certificate validity is tested in accordance with testing performed for FIA_X509_EXT.1/ITT.
-
-*FCS_TLSC_EXT.1.4* The TSF shall [selection: _not present the Supported Elliptic Curves/Supported Groups Extension, present the Supported Elliptic Curves/Supported Groups Extension with the following curves/groups:_ [selection: _secp256r1, secp384r1, secp521r1, ffdhe2048, ffdhe3072, ffdhe4096, ffdhe6144, ffdhe8192_] _and no other curves/groups_] in the Client Hello.
+*FCS_TLSC_EXT.1.4* The TSF shall [selection: _not present the Supported Groups Extension, present the Supported Groups Extension with the following curves/groups:[selection: secp256r1, secp384r1, secp521r1, ffdhe2048, ffdhe3072, ffdhe4096, ffdhe6144, ffdhe8192]and no other curves/groups_] in the Client Hello.
 
 *_Application Note {counter:appnote_count}_*
 
+_The “Supported Elliptic Curves” extension was renamed to “Supported Groups” by RFC 7919; however, both terms refer to the same extension._
 
-If ciphersuites with elliptic curves were selected in FCS_TLSC_EXT.1.1, a selection of one or more curves is required. If no ciphersuites with elliptic curves were selected in FCS_TLSC_EXT.1.1, then “not present the Support Elliptic Curves/Supported Groups Extension” should be selected.
+_The following table provides the ST author with instructions for completing the selections._
 
-This requirement limits the elliptic curves allowed for authentication and key agreement to the NIST curves from FCS_COP.1/SigGen and FCS_CKM.1 and FCS_CKM.2. This extension is required for clients supporting Elliptic Curve ciphersuites.
+[cols="1,1,1"]
+|===
+| |_not present the Supported Groups Extension_|_present the Supported Groups Extension_
+|_TLS 1.3 with or without TLS 1.2 or TLS 1.1_|_Shall not select_|_Shall select with any secp curves or any ffdhe groups – If TLS 1.2 or TLS 1.1 is supported, see the following rows for additional instructions._
+|_TLS 1.2 or TLS 1.1 with support for at least one ECDHE ciphersuite_|_Shall not select_|_Shall select – at least one secp curve shall be selected_
+|_TLS 1.2 or TLS 1.1 with support for at least one DHE ciphersuite_|_May select_ +
 
-If ciphersuites with DHE key agreement were selected FCS_TLSC_EXT.1.1 and the TOE supports TLS FFC groups (e.g. ffdhe2048), this extension is required. This extension is not required if the TOE only supports non-TLS FFC groups (e.g. Group 14).
+_This extension is not required, because older TLS implementations did not negotiate FFC parameters (e.g. Group 14)._|_May select – at least one ffdhe group shall be selected_
+|===
 
-*FCS_TLSS_EXT.1 TLS Server Protocol*
+_Subsequent versions of this cPP will require support for the Supported Groups extension and prohibit use of legacy DH groups for key establishment._
+
+*FCS_TLSC_EXT.1.5* The TSF shall [selection:
+
+* _present the signature_algorithms extension with support for the following algorithms: +
+[selection:_
+
+** _rsa_pkcs1 with sha256(0x0401),_
+** _rsa_pkcs1with sha384(0x0501),_
+** _rsa_pkcs1 with sha512(0x0601),_
+** _ecdsa_secp256r1 with sha256(0x0403),_
+** _ecdsa_secp384r1 with sha384(0x0503),_
+** _ecdsa_secp521r1 with sha512(0x0603),_
+** _rsa_pss_rsae with sha256(0x0804),_
+** _rsa_pss_rsae with sha384(0x0805),_
+** _rsa_pss_rsae with sha512(0x0806),_
+** _rsa_pss_pss with sha256(0x0809),_
+** _rsa_pss_pss with sha384(0x080a),_
+** _rsa_pss_pss with sha512(0x080b)_
+** ] and no other algorithms;
+
+* _present the signature_algorithms_cert extension with the following Signature Schemes:_ +
+_[selection:_
+
+** _rsa_pkcs1 with sha256(0x0401),_
+** _rsa_pkcs1with sha384(0x0501),_
+** _rsa_pkcs1 with sha512(0x0601),_
+** _ecdsa_secp256r1 with sha256(0x0403),_
+** _ecdsa_secp384r1 with sha384(0x0503),_
+** _ecdsa_secp521r1 with sha512(0x0603),_
+** _rsa_pss_rsae with sha256(0x0804),_
+** _rsa_pss_rsae with sha384(0x0805),_
+** _rsa_pss_rsae with sha512(0x0806),_
+** _rsa_pss_pss with sha256(0x0809),_
+** _rsa_pss_pss with sha384(0x080a),_
+** _rsa_pss_pss with sha512(0x080b)_
+** _] and no other SignatureSchemes;_
+
+_]._
+
+*_Application Note {counter:appnote_count}_*
+
+_The selected algorithms and SignatureSchemes must be consistent with FCS_COP.1/SigGen and FCS_COP.1/Hash._
+
+_TLS 1.2 and TLS 1.3 define different signature_algorithms extension formats. TLS 1.2 specifies the HashAlgorithm and SignatureAlgorithm independently while TLS 1.3 specifies SignatureSchemes. This element intentionally limits the signature and hash algorithms that may be selected_
+
+_The following table provides the ST author with instructions for completing the selections._
+
+[cols="1,1,1"]
+|===
+| |_present the signature_algorithms extension_|_present the signature_algorithms_cert extension_
+|_TLS 1.3_|_Shall select_|_May select_
+|_TLS 1.2 without TLS 1.3_|_May select_|_Shall not select_
+|===
+
+*FCS_TLSC_EXT.1.6* The TSF [selection: _provides, does not provide_] the ability to configure the list of supported ciphersuites as defined in FCS_TLSC_EXT.1.1.
+
+*_Application Note {counter:appnote_count}_*
+
+_The option 'provides' shall be selected if the TOE provides the ability to configure the list of ciphers as defined in FCS_TLSC_EXT.1.1 (e.g. enabling/disabling of ciphers, ordering, assigning priorities). Otherwise the option 'does not provide' shall be selected._
+
+*FCS_TLSC_EXT.1.7* The TSF _shall prohibit the use of the following extensions:_
+
+* _Early data extension_
+* _post-handshake client authentication according to RFC 8446, section 4.2.6._
+
+*_Application Note {counter:appnote_count}_*
+
+_The use of the early data extension and the post-handshake client authentication is prohibited in the configured TOE. Prohibiting post-handshake client authentication might be dropped in a future version of NDcPP._
+
+*FCS_TLSC_EXT.1.8* The TSF shall not permit TLS 1.3 connections using an out-of-band provisioned pre-shared key (PSK).  Any use of PSKs in TLS 1.3 must use (EC)DHE to provide forward secrecy.
+
+*_Application Note {counter:appnote_count}_*
+
+_The use of out-of-band provisioned pre-shared keys creates a potential security concern since the entropy used to generate the PSK is outside of the control of the TOE.  PSKs are used in TLSv1.3 to provide session resumption; however, in this case, the TSF is responsible for generating appropriately strong keying material.  Use of (EC)DHE further enhances security when using PSKs by providing forward secrecy._
 
 *FCS_TLSS_EXT.1.1* The TSF shall implement [selection: _TLS 1.3 (RFC 8446), TLS 1.2 (RFC 5246)_] and [selection: _TLS 1.1 (RFC 4346), no additional TLS version_] and reject all other TLS and SSL versions. The TLS implementation will support the following ciphersuites:
 
@@ -3888,7 +3971,7 @@ The following actions should be considered for audit if FAU_GEN Security audit d
 . TLS session establishment
 . TLS session termination
 
-*FCS_TLSC_EXT.1 TLS Client Protocol without Mutual Authentication*
+*FCS_TLSC_EXT.1 TLS Client Protocol*
 
 ____
 Hierarchical to: No other components
@@ -3912,24 +3995,71 @@ FIA_X509_EXT.1 X.509 Certificate Validation
 FIA_X509_EXT.2 X.509 Certificate Authentication
 ____
 
-*FCS_TLSC_EXT.1.1* The TSF shall implement [selection: _TLS 1.2 (RFC 5246), TLS 1.1 (RFC 4346)_] and reject all other TLS and SSL versions. The TLS implementation will support the following ciphersuites:
+*FCS_TLSC_EXT.1.1* The TSF shall implement [selection: _TLS 1.3 (RFC 8446), TLS 1.2 (RFC 5246)_] and [selection: _TLS 1.1 (RFC 4346), no additional TLS version_] and reject all other TLS and SSL versions. The TLS implementation will support the following ciphersuites:
 
-* {blank}
-+
-____
-_[assignment: list of optional ciphersuites and reference to RFC in which each is defined]_ and no other ciphersuites__.__
-____
+[selection:
+
+* [.underline]#_select supported ciphersuites for TLSv1.1 and/or TLSv1.2 from List 1_#
+
+* [.underline]#_select supported ciphersuites for TLSv1.3 from List 2_#
+
+] _and no other ciphersuites_.
 
 *FCS_TLSC_EXT.1.2* The TSF shall verify that the presented identifier matches [selection: _the reference identifier per RFC 6125 section 6, IPv4 address in CN or SAN, IPv6 address in the CN or SAN, IPv4 address in SAN, IPv6 address in the SAN, the identifier per RFC 5280 Appendix A using [selection: id-at-commonName, id-at-countryName, id-at-dnQualifier, id-at-generationQualifier, id-at-givenName, id-at-initials, id-at-localityName, id-at-name, id-at-organizationalUnitName, id-at-organizationName, id-at-pseudonym, id-at-serialNumber, id-at-stateOrProvinceName, id-at-surname, id-at-title] and no other attribute types_].
 
-*FCS_TLSC_EXT.1.3* When establishing a trusted channel, by default the TSF shall not establish a trusted channel if the server certificate is invalid. The TSF shall also [selection:
+*FCS_TLSC_EXT.1.3* The TSF shall not establish a trusted channel if the server certificate is invalid [selection:
 
-* _Not implement any administrator override mechanism_
-* _require administrator authorization to establish the connection if the TSF fails to [selection: match the reference identifier, validate certificate path, validate expiration date, determine the revocation status] of the presented server certificate_
+* _without any administrator override mechanism_
+* _except with the following administrator override:   If the TSF fails to [selection: match the reference identifier, validate certificate path, validate expiration date, determine the revocation status] the TSF shall allow the administrator to provide override authorization to establish the connection on a per certificate basis._
 
 ].
 
-*FCS_TLSC_EXT.1.4* The TSF shall [selection: _not present the Supported Elliptic Curves/Supported Groups Extension, present the Supported Elliptic Curves/Supported Groups Extension with the following curves/groups: [selection: secp256r1, secp384r1, secp521r1, ffdhe2048, ffdhe3072, ffdhe4096, ffdhe6144, ffdhe8192] and no other curves/groups_] in the Client Hello.
+*FCS_TLSC_EXT.1.4* The TSF shall [selection: _not present the Supported Groups Extension, present the Supported Groups Extension with the following curves/groups: [selection: secp256r1, secp384r1, secp521r1, ffdhe2048, ffdhe3072, ffdhe4096, ffdhe6144, ffdhe8192] and no other curves/groups_] in the Client Hello.
+
+*FCS_TLSC_EXT.1.5* The TSF shall [selection:
+
+* _present the signature_algorithms extension with support for the following algorithms: +
+[selection:_
+** _rsa_pkcs1 with sha256(0x0401),_
+** _rsa_pkcs1with sha384(0x0501),_
+** _rsa_pkcs1 with sha512(0x0601),_
+** _ecdsa_secp256r1 with sha256(0x0403),_
+** _ecdsa_secp384r1 with sha384(0x0503),_
+** _ecdsa_secp521r1 with sha512(0x0603),_
+** _rsa_pss_rsae with sha256(0x0804),_
+** _rsa_pss_rsae with sha384(0x0805),_
+** _rsa_pss_rsae with sha512(0x0806),_
+** _rsa_pss_pss with sha256(0x0809),_
+** _rsa_pss_pss with sha384(0x080a),_
+** _rsa_pss_pss with sha512(0x080b)_
+** ] and no other algorithms;
+
+* _present the signature_algorithms_cert extension with the following Signature Schemes:_ +
+_[selection:_
+** _rsa_pkcs1 with sha256(0x0401),_
+** _rsa_pkcs1with sha384(0x0501),_
+** _rsa_pkcs1 with sha512(0x0601),_
+** _ecdsa_secp256r1 with sha256(0x0403),_
+** _ecdsa_secp384r1 with sha384(0x0503),_
+** _ecdsa_secp521r1 with sha512(0x0603),_
+** _rsa_pss_rsae with sha256(0x0804),_
+** _rsa_pss_rsae with sha384(0x0805),_
+** _rsa_pss_rsae with sha512(0x0806),_
+** _rsa_pss_pss with sha256(0x0809),_
+** _rsa_pss_pss with sha384(0x080a),_
+** _rsa_pss_pss with sha512(0x080b)_
+** _] and no other SignatureSchemes;_
+
+_]._
+
+*FCS_TLSC_EXT.1.6* The TSF [selection: _provides, does not provide_] the ability to configure the list of supported ciphersuites as defined in FCS_TLSC_EXT.1.1.
+
+*FCS_TLSC_EXT.1.7* The TSF _shall prohibit the use of the following extensions:_
+
+* _Early data extension_
+* _post-handshake client authentication according to RFC 8446, section 4.2.6._
+
+*FCS_TLSC_EXT.1.8* The TSF shall not permit TLS 1.3 connections using an out-of-band provisioned pre-shared key (PSK).  Any use of PSKs in TLS 1.3 must use (EC)DHE to provide forward secrecy.
 
 *FCS_TLSC_EXT.2 TLS Client Support for Mutual Authentication*
 

--- a/NDcPP_v2_2e.adoc
+++ b/NDcPP_v2_2e.adoc
@@ -2333,61 +2333,117 @@ _The use of the early data extension and the post-handshake client authenticatio
 
 _The use of out-of-band provisioned pre-shared keys creates a potential security concern since the entropy used to generate the PSK is outside of the control of the TOE. PSKs are used in DTLS 1.3 to provide session resumption; however, in this case, the TSF is responsible for generating appropriately strong keying material.  Use of (EC)DHE further enhances security when using PSKs by providing forward secrecy._
 
-*FCS_DTLSS_EXT.1 DTLS Server Protocol Without Mutual Authentication*
+*FCS_DTLSS_EXT.1 DTLS Server Protocol*
 
-*FCS_DTLSS_EXT.1.1* The TSF shall implement [selection: _DTLS 1.2 (RFC 6347), DTLS 1.0 (RFC 4347)_] supporting the following ciphersuites:
+*FCS_DTLSS_EXT.1.1* The TSF shall implement [selection: _DTLS 1.3 (RFC tbd), DTLS 1.2 (RFC 6347)_] and [selection: _DTLS 1.0 (RFC 4347), no additional DTLS version_] supporting the following ciphersuites:
 
 * [selection:
-** _select supported ciphersuites from List 1]_ and no other ciphersuites.
+** _select supported ciphersuites for DTLS 1.0/1.2 from List 1_
+** _select supported ciphersuites for DTLS 1.3 from List 2_
+
++
+] and no other ciphersuites.
 
 *_Application Note {counter:appnote_count}_*
 
-_The ciphersuites to be tested in the evaluated configuration are limited by this requirement and must be selected from the ciphersuites defined in List 1, chap._ _B.3.1.6. The ST author should select the ciphersuites that are supported._ _Even though RFC 5246 and RFC 6347 mandate implementation of specific ciphers, there is no requirement to implement TLS_RSA_WITH_AES_128_CBC_SHA in order to claim conformance to this cPP._
+_The ciphersuites to be tested in the evaluated configuration are limited by this requirement and must be selected from the ciphersuites defined in List 1, chap. B.3.1.6. The ST author should select the ciphersuites that are supported. Even though RFC 5246 and RFC 6347 mandate implementation of specific ciphers, this cPP depreciates use of SHA-1. Support for TLS_RSA_WITH_AES_128_CBC_SHA is not claimed in order to claim conformance to this cPP._
 
 _These requirements will be revisited as new DTLS versions are standardized by the IETF._
 
-_In a future version of this cPP DTLS v1.2 will be required for all TOEs._
-
-*FCS_DTLSS_EXT.1.2* The TSF shall deny connections from clients requesting _none_.
-
-*_Application Note {counter:appnote_count}_*
-
 _This version of the cPP does not require the TOE to deny DTLS v1.0. In a future version of this cPP DTLS v1.0 will be required to be denied for all TOEs._
 
-*FCS_DTLSS_EXT.1.3* The TSF shall not proceed with a connection handshake attempt if the DTLS Client fails validation.
+*FCS_DTLSS_EXT.1.2* The TSF shall not proceed with a connection handshake attempt if the DTLS server cannot successfully validate the cookie returned by the DTLS Client.
 
 *_Application Note {counter:appnote_count}_*
 
-_The process to validate the DTLS client is specified in section 4.2.1 of RFC 6347 (DTLS 1.2) and RFC 4347 (DTLS 1.0). The TOE validates the DTLS client during Connection Establishment (Handshaking) and prior to the TSF sending a Server Hello message. After receiving a ClientHello, the DTLS Server sends a HelloVerifyRequest along with a cookie. The cookie is a signed message using the keyed hash function specified in FCS_COP.1/KeyedHash. The DTLS Client then sends another ClientHello with the cookie attached. If the DTLS server successfully verifies the signed cookie, the Client is not using a spoofed IP address._
+_The process to validate the DTLS client is specified in section tbd of RFC tbd (DTLS 1.3), section 4.2.1 of RFC 6347 (DTLS 1.2) and RFC 4347 (DTLS 1.0). The TOE validates the DTLS client during Connection Establishment (Handshaking) and prior to the TSF sending a Server Hello message. After receiving a ClientHello, the DTLS Server sends a HelloRetryRequest message (DTLS 1.3)/HelloVerify message (DTLS 1.2/1.0) along with a cookie. The cookie is a signed message using the keyed hash function specified in FCS_COP.1/KeyedHash. The DTLS Client then sends another ClientHello with the cookie attached. If the DTLS server successfully verifies the signed cookie, the Client is not using a spoofed IP address._
 
-*FCS_DTLSS_EXT.1.4* The TSF shall perform key establishment for TLS using [selection: _RSA with key size_ [selection: _2048 bits, 3072 bits, 4096 bits], Diffie-Hellman parameters with size_ [selection: _2048 bits, 3072 bits, 4096 bits, 6144 bits, 8192 bits], Diffie-Hellman groups_ [selection: _ffdhe2048, ffdhe3072, ffdhe4096, ffdhe6144, ffdhe8192, no other groups], ECDHE curves_ [selection: _secp256r1, secp384r1, secp521r1] and no other curves_].
+*FCS_DTLSS_EXT.1.3* The TSF shall authenticate itself using X.509 certificate(s) using [selection: _RSA with key size [selection: 2048 bits, 3072 bits, 4096 bits]; ECDSA over NIST curves [selection: secp256r1, secp384r1, secp521r1] and no other curves_].
 
 *_Application Note {counter:appnote_count}_*
 
-_The appropriate options shall be selected in the ST according to the key establishment options supported by the TOE. FMT_SMF.1 requires the configuration of the key agreement parameters to establish the security strength of the DTLS connection._
+_The selected algorithms and key sizes must be consistent with FCS_COP.1/SigGen and FCS_CKM.1. NDcPP does not support raw public keys as defined in RFC8446._
+
+_If the ST includes DTLS 1.0 or DTLS 1.2 in FCS_DTLSS_EXT.1.1, the selected algorithms must be consistent with the ciphersuites selected in FCS_DTLSS_EXT.1.1._
+
+*FCS_DTLSS_EXT.1.4* The TSF shall perform key exchange using: [selection:
+
+* _RSA key establishment with key size [selection: 2048 bits, 3072 bits, 4096 bits];_
+* _EC Diffie-Hellman key agreement over NIST curves [selection: secp256r1, secp384r1, secp521r1] and no other curves;_
+* _Diffie-Hellman parameters [selection: of size 2048 bits, of size 3072 bits, of size 4096 bits, of size 6144 bits, of size 8192 bits, ffdhe2048, ffdhe3072, ffdhe4096, ffdhe6144, ffdhe8192]_
+
+].
+
+*_Application Note {counter:appnote_count}_*
+
+_The selected algorithms and key sizes must be consistent with FCS_CKM.2._
+
+_The following table provides the ST author with instructions for completing the selections._
+
+[cols=",,,",options="header",]
+|===
+| |_RSA key establishment..._|_EC Diffie-Hellman key agreement..._|_Diffie-Hellman key agreement..._
+|_DTLS 1.3 without DTLS 1.2 or DTLS 1.0_|_Shall not select_ 2+|_Shall select at least one_
+|_DTLS 1.3 with DTLS 1.2 or DTLS 1.0_|_See the following rows_ 2+|_Shall select at least one - see the following rows for additional instructions_
+|_DTLS 1.2 or DTLS 1.0 with support for at least one TLS_RSA_WITH... ciphersuite_|_Shall select_|_N/A_|_N/A_
+|_DTLS 1.2 or DTLS 1.0 without support for any TLS_RSA_WITH... ciphersuites_|_Shall not select_|_N/A_|_N/A_
+|_DTLS 1.2 or DTLS 1.0 with support for at least one ECDHE ciphersuite_|_N/A_|_Shall select_|_N/A_
+|_DTLS 1.2 or DTLS 1.0 without support for DTLS 1.3 or any ECDHE ciphersuites_|_N/A_|_Shall not select_|_N/A_
+|_DTLS 1.2 & DTLS 1.0 with support for at least one DHE ciphersuite_|_N/A_|_N/A_|_Shall select_
+|_DTLS 1.2 & DTLS 1.0 without support for DTLS 1.3 or any DHE ciphersuites_|_N/A_|_N/A_|_Shall not select_
+|===
+
+_N/A indicates the options do not affect whether the selection is selected or not._
+
+_The RSA key size(s) specified in FCS_DTLSS_EXT.1.4 are used for RSA key establishment._
+
+_Subsequent versions of this cPP will require support for the Supported Groups extension and prohibit use of legacy DH groups for key establishment._
 
 *FCS_DTLSS_EXT.1.5* The TSF shall [selection: _terminate the DTLS session, silently discard the record_] if a message received contains an invalid MAC.
 
 *_Application Note {counter:appnote_count}_*
 
-_The Message Authentication Code (MAC) is negotiated during DTLS handshake phase and is used to protect integrity of messages received from the sender during DTLS data exchange. If MAC verification fails, the session must be terminated, or the record must be silently discarded._
+_The Message Authentication Code (MAC) is negotiated during DTLS handshake phase and is used to protect integrity of messages received from the sender during DTLS data exchange (see 'Handling Invalid Records' in RFC (tbd - current draft for DTLS 1.3 is V38), section 4.5.2 and 4.1.2.7 in RFC 6347(DTLS 1.2)).  If MAC verification fails, the session must be terminated or the record must be silently discarded._
 
 *FCS_DTLSS_EXT.1.6* The TSF shall detect and silently discard replayed messages for:
 
 * DTLS records previously received.
 * DTLS records too old to fit in the sliding window.
 
+
 *_Application Note {counter:appnote_count}_*
 
-_Replay Detection is described in section 4.1.2.6 of DTLS 1.2 (RFC 6347) and section 4.1.2.5 of DTLS 1.0 (RFC 4347). For each received record, the receiver verifies the record contains a sequence number that is within the sliding receive window and does not duplicate the sequence number of any other record received during the session._
+_Replay Detection is described in section 4.5.1 of DTLS 1.3 (RFC tbd, current draft version is V38), 4.1.2.6 of DTLS 1.2 (RFC 6347) and section 4.1.2.5 of DTLS 1.0 (RFC 4347).  For each received record, the receiver verifies the record contains a sequence number that is within the sliding receive window and does not duplicate the sequence number of any other record received during the session._
 
 _"Silently Discard" means the TOE discards the packet without responding._
 
-*FCS_DTLSS_EXT.1.7* The TSF shall support [selection: _no session resumption or session tickets, session resumption based on session IDs according to RFC 4346 (TLS1.1) or RFC 5246 (TLS1.2), session resumption based on session tickets according to RFC 5077_].
+*FCS_DTLSS_EXT.1.7* The TSF shall support [selection: _no session resumption or session tickets, session resumption based on session IDs according to RFC4346 (TLS1.1) or RFC5246 (TLS1.2), session resumption based on session tickets according to RFC5077 (TLS1.2), session resumption according to RFC8446 (TLS1.3)_].
 
 *_Application Note {counter:appnote_count}_*
 
-_If the TOE does not support session resumption or session tickets, select 'no session resumption or session tickets’. If the TOE supports session resumption based on session IDs according to RFC 4346 (TLS1.1) or RFC 5246 (TLS1.2), select 'session resumption based on session IDs according to RFC 4346 (TLS1.1) or RFC 5246 (TLS1.2)'. If the TOE supports session resumption based on session tickets according to RFC 5077, select 'session resumption based on session tickets according to RFC 5077'._
+_If the TOE doesn't support session resumption or session tickets, select 'no session resumption or session tickets'. If the TOE supports session resumption based on session IDs according to RFC4346 (TLS1.1) or RFC5246 (TLS1.2), select 'session resumption based on session IDs according to RFC4346 (TLS1.1) or RFC5246 (TLS1.2)'. If the TOE supports session resumption based on session tickets according to RFC5077, select 'session resumption based on session tickets according to RFC5077 (TLS1.2)'. If the TOE supports session resumption according to RFC8446 (TLS1.3), select 'session resumption according to RFC8446 (TLS1.3)'._
+
+*FCS_DTLSS_EXT.1.8* The TSF [selection: _provides, does not provide_] the ability to configure the list of supported ciphersuites as defined in FCS_DTLSS_EXT.1.1.
+
+*_Application Note {counter:appnote_count}_*
+
+_The option 'provides' shall be selected if the TOE allows configuration of the list of ciphers as defined in FCS_DTLSS_EXT.1.1 (e.g. enabling/disabling of ciphers, ordering, assigning priorities). Otherwise the option 'does not provide' shall be selected._
+
+*FCS_DTLSS_EXT.1.9* The TSF shall prohibit the use of the following extensions:
+
+* _Early data extension_
+
+
+*_Application Note {counter:appnote_count}_*
+
+_The use of the early data extension is prohibited in the configured TOE._
+
+*FCS_DTLSS_EXT.1.10* The TSF shall not permit DTLS 1.3 connections using an out-of-band provisioned pre-shared key (PSK).  Any use of PSKs in DTLS 1.3 must use (EC)DHE to provide forward secrecy.
+
+*_Application Note {counter:appnote_count}_*
+
+_The use of out-of-band provisioned pre-shared keys creates a potential security concern since the entropy used to generate the PSK is outside of the control of the TOE.  PSKs are used in DTLS 1.3 to provide session resumption; however, in this case, the TSF is responsible for generating appropriately strong keying material.  Use of (EC)DHE further enhances security when using PSKs by providing forward secrecy._
+
 
 =====  FCS_HTTPS_EXT HTTPS Protocol
 
@@ -2996,11 +3052,11 @@ _Subsequent versions of this cPP will require support for the Supported Groups e
 
 _If the TOE doesn't support session resumption or session tickets, select 'no session resumption'. If the TOE supports session resumption based on session IDs according to RFC4346 (TLS1.1) or RFC5246 (TLS1.2), select 'sessiion resumption based on session IDs according to RFC4346 (TLS1.1) or RFC5246 (TLS1.2)'. If the TOE supports session resumption based on session tickets according to RFC5077, select 'session resumption based on session tickets according to RFC5077 (TLS1.2)'. If the TOE supports session resumption according to RFC8446 (TLS1.3), select 'session resumption according to RFC8446 (TLS1.3)'._
 
-*FCS_TLSS_EXT.1.5* The TSF [selection: _provide, do not provide_] the ability of configuring the list of supported ciphersuites as defined in FCS_TLSS_EXT.1.1. 
+*FCS_TLSS_EXT.1.5* The TSF [selection: _provides, does not provide_] the ability to configure the list of supported ciphersuites as defined in FCS_TLSS_EXT.1.1.
 
 *_Application Note {counter:appnote_count}_*
 
-_The option 'provide' shall be selected if the TOE allows to configure the list of ciphers as defined in FCS_TLSS_EXT.1.1 (e.g., enabling/disabling of ciphers, ordering, assigning priorities). Otherwise the option 'do not provide' shalled be selected._
+_The option 'provides' shall be selected if the TOE allows configuration of the list of ciphers as defined in FCS_TLSS_EXT.1.1 (e.g. enabling/disabling of ciphers, ordering, assigning priorities). Otherwise the option 'does not provide' shall be selected._
 
 *FCS_TLSS_EXT.1.6* The TSF _shall prohibit the use of the following extensions:_
 
@@ -3588,9 +3644,9 @@ Dependencies: FCS_CKM.1 Cryptographic Key Generation
 
 FCS_CKM.2 Cryptographic Key Establishment
 
-FCS_COP.1//DataEncryption Cryptographic operation (AES Data encryption/decryption)
+FCS_COP.1/DataEncryption Cryptographic operation (AES Data encryption/decryption)
 
-FCS_COP.1//SigGen Cryptographic operation (Signature Generation and Verification)
+FCS_COP.1/SigGen Cryptographic operation (Signature Generation and Verification)
 
 FCS_COP.1/Hash Cryptographic operation (Hash Algorithm)
 
@@ -3603,24 +3659,42 @@ FIA_X509_EXT.1 X.509 Certificate Validation
 FIA_X509_EXT.2 X.509 Certificate Authentication
 ____
 
-*FCS_DTLSS_EXT.1.1* The TSF shall implement [selection: _DTLS 1.2 (RFC 6347), DTLS 1.0 (RFC 4347)_] supporting the following ciphersuites:
+*FCS_DTLSS_EXT.1.1* The TSF shall implement [selection: _DTLS 1.3 (RFC tbd), DTLS 1.2 (RFC 6347)_] and [selection: _DTLS 1.0 (RFC 4347), no additional DTLS version_] supporting the following ciphersuites:
 
-* _[assignment: List of optional ciphersuites and reference to RFC in which each is defined]_
+* [selection:
+** _select supported ciphersuites for DTLS 1.0/1.2 from List 1_
+** _select supported ciphersuites for DTLS 1.3 from List 2_
 
-*FCS_DTLSS_EXT.1.2* The TSF shall deny connections from clients requesting _[assignment: list of protocol versions]_.
++
+] and no other ciphersuites.
 
-*FCS_DTLSS_EXT.1.3* The TSF shall not proceed with a connection handshake attempt if the DTLS Client fails validation.
+*FCS_DTLSS_EXT.1.2* The TSF shall not proceed with a connection handshake attempt if the DTLS server cannot successfully validate the cookie returned by the DTLS Client.
 
-*FCS_DTLSS_EXT.1.4* The TSF shall perform key establishment for TLS using [selection: _RSA with key size [selection: 2048 bits, 3072 bits, 4096 bits], Diffie-Hellman parameters with size_ [selection__: 2048 bits, 3072 bits, 4096 bits, 6144 bits, 8192 bits], Diffie-Hellman groups__ [selection__: ffdhe2048, ffdhe3072, ffdhe4096, ffdhe6144, ffdhe8192, no other groups], ECDHE curves [selection: secp256r1, secp384r1, secp521r1] and no other curves__].
+*FCS_DTLSS_EXT.1.3* The TSF shall authenticate itself using X.509 certificate(s) using [selection: _RSA with key size [selection: 2048 bits, 3072 bits, 4096 bits]; ECDSA over NIST curves [selection: secp256r1, secp384r1, secp521r1] and no other curves_].
+
+*FCS_DTLSS_EXT.1.4* The TSF shall perform key exchange using: [selection:
+
+* _RSA key establishment with key size [selection: 2048 bits, 3072 bits, 4096 bits];_
+* _EC Diffie-Hellman key agreement over NIST curves [selection: secp256r1, secp384r1, secp521r1] and no other curves;_
+* _Diffie-Hellman parameters [selection: of size 2048 bits, of size 3072 bits, of size 4096 bits, of size 6144 bits, of size 8192 bits, ffdhe2048, ffdhe3072, ffdhe4096, ffdhe6144, ffdhe8192]_
+
+].
 
 *FCS_DTLSS_EXT.1.5* The TSF shall [selection: _terminate the DTLS session, silently discard the record_] if a message received contains an invalid MAC.
 
-*FCS_DTLSS_EXT.1.6* The TSF shall detect and silently discard replayed messages for:
+*FCS_DTLSS_EXT.1.6* The TSF shall detect and silently discard replayed messages for: 
 
 * DTLS records previously received.
 * DTLS Records too old to fit in the sliding window.
 
-*FCS_DTLSS_EXT.1.7* The TSF shall support [selection: _no session resumption or session tickets, session resumption based on session IDs according to RFC 4346 (TLS1.1) or RFC 5246 (TLS1.2), session resumption based on session tickets according to RFC 5077_].
+
+*FCS_DTLSS_EXT.1.7* The TSF shall support [selection: _no session resumption or session tickets, session resumption based on session IDs according to RFC4346 (TLS1.1) or RFC5246 (TLS1.2), session resumption based on session tickets according to RFC5077 (TLS1.2), session resumption according to RFC8446 (TLS1.3)_].
+
+*FCS_DTLSS_EXT.1.8* The TSF [selection: _provides, does not provide_] the ability to configure the list of supported ciphersuites as defined in FCS_DTLSS_EXT.1.1.
+
+*FCS_DTLSS_EXT.1.9* The TSF shall prohibit the use of the following extensions: [assignment: _list of prohibited DTLS extensions_].
+
+*FCS_DTLSS_EXT.1.10* The TSF shall not permit DTLS 1.3 connections using an out-of-band provisioned pre-shared key (PSK).  Any use of PSKs in DTLS 1.3 must use (EC)DHE to provide forward secrecy.
 
 ____
 *FCS_DTLSS_EXT.2 DTLS Server Support for Mutual Authentication*
@@ -4249,7 +4323,7 @@ ____
 
 *FCS_TLSS_EXT.1.4* The TSF shall support [selection: _no session resumption, session resumption based on session IDs according to RFC4346 (TLS1.1) or RFC5246 (TLS1.2), session resumption based on session tickets according to RFC5077 (TLS1.2), session resumption according to RFC8446 (TLS1.3)_].
 
-*FCS_TLSS_EXT.1.5* The TSF [selection: _provide, do not provide_] the ability of configuring the list of supported ciphersuites as defined in FCS_TLSS_EXT.1.1.
+*FCS_TLSS_EXT.1.5* The TSF [selection: _provides, does not provide_] the ability to configure the list of supported ciphersuites as defined in FCS_TLSS_EXT.1.1.
 
 *FCS_TLSS_EXT.1.6* The TSF _shall prohibit the use of the following extensions:_
 


### PR DESCRIPTION
Removed FCS_TLSS_EXT.3.2 and combined it with FCS_TLSS_EXT.3.1, to replace the old FCS_TLSS_EXT.3.1.  Updated the title of FCS_TLSS_EXT.3 to say 'secure renegotiation'.
