### PR TITLE
Addition of Ed25519 support

### DIFF
--- a/ND_Supporting_Document_3_0.adoc
+++ b/ND_Supporting_Document_3_0.adoc
@@ -331,6 +331,17 @@ _FIPS 186-4 Public Key Verification (PKV) Test_
 [arabic, start=57]
 . For each supported NIST curve, i.e., P-256, P-384 and P-521, the evaluator shall generate 10 private/public key pairs using the key generation function of a known good implementation and modify five of the public key values so that they are incorrect, leaving five values unchanged (i.e., correct). The evaluator shall obtain in response a set of 10 PASS/FAIL values.
 
+*Key Generation for FIPS PUB 186-5*
+
+_FIPS 186-5 Key Generation Test_
+
+[arabic, start=58]
+. For the Ed25519 curve, the evaluator shall require the implementation under test (IUT) to generate 10 private/public key pairs. The private key shall be generated using an approved random bit generator (RBG). To determine correctness, the evaluator shall submit the generated key pairs to the public key verification (PKV) function of a known good implementation.
+
+_FIPS 186-5 Key Verification Test_
+[arabic, start=59]
+. For the Ed25519 curve, , the evaluator shall generate 10 private/public key pairs using the key generation function of a known good implementation and modify five of the public key values so that they are incorrect, leaving five values unchanged (i.e., correct). The evaluator shall obtain in response a set of 10 PASS/FAIL values.
+
 *Key Generation for Finite-Field Cryptography (FFC)*
 
 [arabic, start=58]
@@ -575,6 +586,23 @@ CT[i] = AES-ECB-Encrypt(Key, PT) PT = CT[i]
 
 [arabic, start=124]
 . For each supported NIST curve (i.e., P-256, P-384 and P-521) and SHA function pair, the evaluator shall generate a set of 10 1024-bit message, public key and signature tuples and modify one of the values (message, public key or signature) in five of the 10 tuples. The evaluator shall obtain in response a set of 10 PASS/FAIL values.
+
+*EDDSA Algorithm Tests*
+
+*_EDDSA FIPS 186-5 Signature Generation Test_*
+
+[arabic, start=125]
+. The evaluator shall use the Ed25519 curve and the SHA-512 function pair to generate signatures for 10, 1024-bit long messages, and obtain for each message, a public key and the resulting signature values R and S. To determine correctness, the evaluator shall use the signature verification function of a known good implementation.
+
+. The evaluator shall use the Ed25519 curve and the SHA-512 function pair to generate signatures for 10, 1024-bit long messages. The first of these 10 messages will be unique and the subsequent 9 messages shall be derived from the first message by flipping individual bits in the original message. For each of these messages, obtain a public key and the resulting signature values R and S. The evaluator shall verify that the resulting signature values are distinct. Furthermore, to determine correctness, the evaluator shall use the signature verification function of a known good implementation.
+
+
+*_EDDSA FIPS 186-5 Signature Verification Test_*
+
+[arabic, start=126]
+. The evaluator shall use the Ed25519 curve and the SHA-512 function to generate a set of 10 1024-bit messages, public key and signature tuples and modify one of the values (message, public key or signature) in five of the 10 tuples. The evaluator shall obtain in response a set of 10 PASS/FAIL values.
+
+
 
 *RSA Signature Algorithm Tests*
 

--- a/NDcPP_v3_0.adoc
+++ b/NDcPP_v3_0.adoc
@@ -952,6 +952,7 @@ These SFRs support the implementation of the selection-based protocol-level SFRs
 
 * _RSA schemes using cryptographic key sizes of 2048-bit or greater that meet the following: FIPS PUB 186-4, “Digital Signature Standard (DSS)”, Appendix B.3;_
 * _ECC schemes using ‘NIST curves’ [selection: P-256, P-384, P-521] that meet the following: FIPS PUB 186-4, “Digital Signature Standard (DSS)”, Appendix B.4;_
+* _ECC schemes using Ed25519 that meet the following: FIPS PUB 186-5, “Digital Signature Standard (DSS)”, Appendix A.2.3;_
 * _FFC schemes using cryptographic key sizes of 2048-bit or greater that meet the following: FIPS PUB 186-4, “Digital Signature Standard (DSS)”, Appendix B.1_
 * _FFC Schemes using ‘safe-prime’ groups that meet the following: “NIST Special Publication 800-56A Revision 3, Recommendation for Pair-Wise Key Establishment Schemes Using Discrete Logarithm Cryptography” and [selection: RFC 3526, RFC 7919]._
 
@@ -1027,20 +1028,22 @@ _For the first selection of FCS_COP.1.1/DataEncryption, the ST author chooses th
 
 * _RSA Digital Signature Algorithm,_
 * _Elliptic Curve Digital Signature Algorithm_
-
+* _Edwards-Curve Digital Signature Algorithm_ 
 ]
 
 and cryptographic key sizes [selection:
 
 * _For RSA: modulus 2048 bits or greater,_
 * _For ECDSA: 256 bits or greater_
+* _For EdDSA: Ed25519_
 
 ]
 
 that meet the following: [selection:
 
 * _For RSA schemes: FIPS PUB 186-4, “Digital Signature Standard (DSS)”, Section 5.5, using PKCS #1 v2.1 Signature Schemes RSASSA-PSS and/or RSASSA-PKCS1v1_5; ISO/IEC 9796-2, Digital signature scheme 2 or Digital Signature scheme 3,_
-* _For ECDSA schemes: FIPS PUB 186-4, “Digital Signature Standard (DSS)”, Section 6 and Appendix D, Implementing “NIST curves”_ [selection: _P-256, P-384, P-521_]; _ISO/IEC 14888-3, Section 6.4_
+* _For ECDSA schemes: FIPS PUB 186-4, “Digital Signature Standard (DSS)”, Section 6 and Appendix D, Implementing “NIST curves”_ [selection: _P-256, P-384, P-521_]; _ISO/IEC 14888-3, Section 6.4,_ 
+* _For EdDSA schemes: FIPS PUB 186-5, “Digital Signature Standard (DSS)”, Section 7_
 
 ].
 
@@ -1065,6 +1068,11 @@ _The hash selection should be consistent with the overall strength of the algori
 *_Application Note {counter:appnote_count}_*
 
 _The key size [k] in the assignment falls into a range between L1 and L2 (defined in ISO/IEC 10118 for the appropriate hash function). For example, for SHA-256, L1=512, L2=256, where L2<=k<=L1. Select 'implicit' in cases where keyed-hash message authentication is done implicitly (e.g. SSH using AES in GCM mode)._
+
+*FCS_COP.1/eXtendable-Output Function Operation (XOF Algorithm)*
+
+*FCS_COP.1.1/XOF* The TSF shall perform _extendable output function operation_ in accordance with a specified cryptographic algorithm [selection: _SHAKE128_, _SHAKE256_] +++<del>+++and cryptographic key sizes [_assignment:_ _cryptographic key sizes_+++</del>+++] that meet the following: _FIPS PUB 202, "SHA-3 Standard: Permutation-Based Hash and Extendable-Output Functions", Section 2.2_
+
 
 ==== Random Bit Generation (Extended – FCS_RBG_EXT)
 

--- a/NDcPP_v3_0.adoc
+++ b/NDcPP_v3_0.adoc
@@ -1069,9 +1069,6 @@ _The hash selection should be consistent with the overall strength of the algori
 
 _The key size [k] in the assignment falls into a range between L1 and L2 (defined in ISO/IEC 10118 for the appropriate hash function). For example, for SHA-256, L1=512, L2=256, where L2<=k<=L1. Select 'implicit' in cases where keyed-hash message authentication is done implicitly (e.g. SSH using AES in GCM mode)._
 
-*FCS_COP.1/eXtendable-Output Function Operation (XOF Algorithm)*
-
-*FCS_COP.1.1/XOF* The TSF shall perform _extendable output function operation_ in accordance with a specified cryptographic algorithm [selection: _SHAKE128_, _SHAKE256_] +++<del>+++and cryptographic key sizes [_assignment:_ _cryptographic key sizes_+++</del>+++] that meet the following: _FIPS PUB 202, "SHA-3 Standard: Permutation-Based Hash and Extendable-Output Functions", Section 2.2_
 
 
 ==== Random Bit Generation (Extended – FCS_RBG_EXT)


### PR DESCRIPTION
I've included selections and test cases for supporting Ed25519. My reasoning for only including Ed25519 and not Ed448 is that the later requires inclusion of support for cSHAKE XOFs. I did start writing test cases and requirements for cSHAKE, but if we were to include that, it would only be a stop-gap measure. It's best to include support for the full SHA-3 family of hash functions in one go rather than to implement a piece-meal approach. This should be left to a future version of the NDcPP.

I have discussed this approach with @dundiddat, and we are both in agreement that this would be the best way forward.
