### PR TITLE
Completed changes for issues #104 and #117.

### DIFF
--- a/ND_Supporting_Document_3_0.adoc
+++ b/ND_Supporting_Document_3_0.adoc
@@ -169,7 +169,7 @@ _Additional Note for Distributed TOEs_
 ==== FAU_GEN.1 Audit data generation
 
 [arabic, start=20]
-. The main reasons for collecting audit information are to detect and identify error conditions, security violations, etc. and to provide sufficient information to the Security Administrator to resolve the issue. The audit information to be collected according to FAU_GEN.1, and the failure conditions identified in tables 2, 4, and 5 need to enable the Security Administrator at least to detect and identify the problem and provide at least basic information to resolve the issue. Also for this level of detail, the other FAU requirements apply, in particular the need for local and remote storage of audit information according to FAU_STG_EXT.1.
+. The main reasons for collecting audit information are to detect and identify error conditions, security violations, etc. and to provide sufficient information to the Security Administrator to resolve the issue. The audit information to be collected according to FAU_GEN.1, and the failure conditions identified in tables 2, 4, and 5 need to enable the Security Administrator at least to detect and identify the problem and provide at least basic information to resolve the issue. Also for this level of detail, the other FAU requirements apply, in particular the need for local and remote storage of audit information according to FAU_STG_EXT.1/Remote.
 . The level of detail that needs to be provided to the Security Administrator to actually resolve an issue usually depends on the complexity of the underlying use case. It is expected that a product provides additional levels of auditing to support resolution of error conditions, security violations, etc. beyond the level required by FAU_GEN.1, but it should also be clear that a high level of granularity cannot be maintained on most systems by default due to the high number of audit events that would be generated in such a configuration. It is expected that the TOE will be capable of auditing sufficient information to meet the requirements of FAU_GEN.1. If the TOE allows configuration of the level of auditing without taking the TOE out of the evaluated configuration, some of the audit events required by FAU_GEN.1 may only be recorded after corresponding configuration of the audit functionality.
 . The issue described above explicitly refers to the use of X.509 certificates. In case a certificate-based authentication fails, an error message telling the Security Administrator that ‘something is wrong with the certificate’ shall not be considered as sufficient information about the ‘reason for failure’ as a basic information to resolve the issue. The log message will inform the Security Administrator of at least the following:
 
@@ -214,7 +214,7 @@ _Additional Note for Distributed TOEs_
 . This activity should be accomplished in conjunction with the testing of FAU_GEN.1.1.
 . For distributed TOEs the evaluator shall verify that where auditable events are instigated by another component, the component that records the event associates the event with the identity of the instigator. The evaluator shall perform at least one test on one component where another component instigates an auditable event. The evaluator shall verify that the event is recorded by the component as expected and the event is associated with the instigating component. It is assumed that an event instigated by another component can at least be generated for building up a secure channel between two TOE components. If for some reason (could be e.g. TSS or Guidance Documentation) the evaluator would come to the conclusion that the overall TOE does not generate any events instigated by other components, then this requirement shall be omitted.
 
-==== FAU_STG_EXT.1 Protected audit event storage
+==== FAU_STG_EXT.1/Remote Protected audit event storage
 
 ===== TSS
 
@@ -238,6 +238,7 @@ _Additional Note for Distributed TOEs_
 . Testing of the trusted channel mechanism for audit will be performed as specified in the associated assurance activities for the particular trusted channel mechanism. The evaluator shall perform the following additional test for this requirement:
 [loweralpha]
 .. Test 1: The evaluator shall establish a session between the TOE and the audit server according to the configuration guidance provided. The evaluator shall then examine the traffic that passes between the audit server and the TOE during several activities of the evaluator’s choice designed to generate audit data to be transferred to the audit server. The evaluator shall observe that these data are not able to be viewed in the clear during this transfer, and that they are successfully received by the audit server. The evaluator shall record the particular software (name, version) used on the audit server during testing. The evaluator shall verify that the TOE is capable of transferring audit data to an external audit server automatically without administrator intervention.
+.. Test 2: For distributed TOEs, Test 1 defined above shall be applicable to all TOE components that forward audit data to an external audit server.
 
 ==== FAU_STG_EXT.1/LocSpace Local audit event storage
 
@@ -264,19 +265,18 @@ _Additional Note for Distributed TOEs_
 [arabic, start=49]
 . The evaluator shall perform the following tests:
 [loweralpha, start=1]
-.. Test 1: The evaluator shall access the local audit trail without authentication as Security Administrator (either by authentication as a non-administrative user, if supported, or without authentication at all) and attempt to modify and delete the audit records. The evaluator shall verify that these attempts fail. If the interface cannot be accessed to attempt the command due to permissions or configuration, this test requirement is satisfied.
-.. Test 2: The evaluator shall perform operations that generate audit data and verify that this data is stored locally. The evaluator shall then make note of whether the TSS claims persistent or non-persistent logging and perform one of the following actions:
+.. Test 1: The evaluator shall perform operations that generate audit data and verify that this data is stored locally. The evaluator shall then make note of whether the TSS claims persistent or non-persistent logging and perform one of the following actions:
 [lowerroman]
 ... If persistent logging is selected, the evaluator shall perform a power cycle of the TOE and ensure that following power on operations the log events generated are still maintained within the local audit storage.
 ... If non-persistent logging is selected, the evaluator shall perform a power cycle of the TOE and ensure that following power on operations the log events generated are no longer present within the local audit storage.
 [loweralpha, start=3]
-.. Test 3: The evaluator shall perform operations that generate audit data until the local storage space is exceeded and verifies that the TOE complies with the behaviour defined in FAU_STG_EXT.1.3. Depending on the configuration this means that the evaluator has to check the content of the audit data when the audit data is just filled to the maximum and then verifies that:
+.. Test 2: The evaluator shall perform operations that generate audit data until the local storage space is exceeded and verifies that the TOE complies with the behaviour defined in FAU_STG_EXT.1.3/LocSpace. Depending on the configuration this means that the evaluator has to check the content of the audit data when the audit data is just filled to the maximum and then verifies that:
 [lowerroman]
 ...	The audit data remains unchanged with every new auditable event that should be tracked but that the audit data is recorded again after the local storage for audit data is cleared (for the option ‘drop new audit data’ in FAU_STG_EXT.1.3/LocSpace).
 ... The existing audit data is overwritten with every new auditable event that should be tracked according to the specified rule (for the option ‘overwrite previous audit records’ in FAU_STG_EXT.1.3/LocSpace)
 ...	The TOE behaves as specified (for the option ‘other action’ in FAU_STG_EXT.1.3/LocSpace).
 [loweralpha, start=4]
-.. Test 4: For distributed TOEs, Test 1 defined above should be applicable to all TOE components that forward audit data to an external audit server. For the local storage according to FAU_STG_EXT.1.2 and FAU_STG_EXT.1.3 the Test 2 specified above shall be applied to all TOE components that store audit data locally. For all TOE components that store audit data locally and comply with FAU_STG_EXT.2 Test 3 specified above shall be applied. The evaluator shall verify that the transfer of audit data to an external audit server is implemented
+.. Test 3: For distributed TOEs, for the local storage according to FAU_STG_EXT.1.2/LocSpace, Test 1 specified above shall be applied to all TOE components that store audit data locally. For all TOE components that store audit data locally and comply with FAU_STG_EXT.2, Test 2 specified above shall be applied. The evaluator shall verify that the transfer of audit data to an external audit server is implemented.
 
 === Cryptographic Support (FCS)
 
@@ -1049,8 +1049,8 @@ In the case where the TOE is able to detect when the cable is removed from the d
 [arabic, start=228]
 . The evaluator shall perform the following tests:
 [loweralpha]
-.. Test 1: The evaluator shall access the audit trail without authentication as Security Administrator (either by authentication as a non-administrative user, if supported, or without authentication at all) and attempt to modify and delete the audit records. The evaluator shall verify that these attempts fail. According to the implementation no other users than the Security Administrator might be defined and without any user authentication the user might not be able to get to the point where the attempt to access the audit trail can be executed. In that case it shall be demonstrated that access control mechanisms prevent execution up to the step that can be reached without authentication as Security Administrator.
-.. Test 2: The evaluator shall access the audit trail as an authorized administrator and attempt to delete the audit records. The evaluator shall verify that these attempts succeed. The evaluator shall verify that only the records authorized for deletion are deleted.
+.. Test 1: The evaluator shall attempt to access the audit trail without authentication as Security Administrator (either by authentication as a non-administrative user, if supported, or without authentication at all) and attempt to modify and delete the audit records. The evaluator shall verify that these attempts fail. According to the implementation no other users than the Security Administrator might be defined and without any user authentication the user might not be able to get to the point where the attempt to access the audit trail can be executed. In that case it shall be demonstrated that access control mechanisms prevent execution up to the step that can be reached without authentication as Security Administrator.
+.. Test 2: The evaluator shall access the audit trail as an authenticated Security Administrator and attempt to delete the audit records (if supported by the TOE, and to the extent described in the TSS). The evaluator shall verify that these attempts succeed. The evaluator shall verify that only the records authorized for deletion are deleted.
 
 [arabic, start=229]
 . For distributed TOEs the evaluator shall perform test 1 and test 2 for each component that is defined by the TSS to be covered by this SFR.
@@ -1058,7 +1058,7 @@ In the case where the TOE is able to detect when the cable is removed from the d
 ==== FAU_STG_EXT.2 Counting lost audit data
 
 [arabic, start=230]
-. This activity should be accomplished in conjunction with the testing of FAU_STG_EXT.1.2 and FAU_STG_EXT.1.3.
+. This activity should be accomplished in conjunction with the testing of FAU_STG_EXT.1.2/LocSpace and FAU_STG_EXT.1.3/LocSpace.
 
 ===== TSS
 
@@ -1075,13 +1075,13 @@ In the case where the TOE is able to detect when the cable is removed from the d
 ===== Tests
 
 [arabic, start=235]
-. The evaluator shall verify that the numbers provided by the TOE according to the selection for FAU_STG_EXT.2 are correct when performing the tests for FAU_STG_EXT.1.3.
+. The evaluator shall verify that the numbers provided by the TOE according to the selection for FAU_STG_EXT.2 are correct when performing the tests for FAU_STG_EXT.1.3/LocSpace.
 . For distributed TOEs the evaluator shall verify the correct implementation of counting of lost audit data for all TOE components that are supporting this feature according to the description in the TSS.
 
 ==== FAU_STG_EXT.3 Action in case of possible audit data loss
 
 [arabic, start=237]
-. This activity should be accomplished in conjunction with the testing of FAU_STG_EXT.1.2 and FAU_STG_EXT.1.3.
+. This activity should be accomplished in conjunction with the testing of FAU_STG_EXT.1.2/LocSpace and FAU_STG_EXT.1.3/LocSpace.
 
 ===== TSS
 
@@ -3043,8 +3043,8 @@ The evaluator does not have to test all possible values of the security related 
 [arabic, start=605]
 . The evaluator shall perform the following tests:
 
-.. Test 1: The evaluator shall try to modify all security related parameters for configuration of the handling of audit data without prior authentication as Security Administrator (by authentication as a user with no administrator privileges or without user authentication at all). Attempts to modify parameters without prior authentication should fail. According to the implementation no other users than the Security Administrator might be defined and without any user authentication the user might not be able to get to the point where the attempt can be executed. In that case it shall be demonstrated that access control mechanisms prevent execution up to the step that can be reached without authentication as Security Administrator. The term ‘handling of audit data’ refers to the different options for selection and assignments in SFRs FAU_STG_EXT.1.2, FAU_STG_EXT.1.3 and FAU_STG_EXT.2.
-.. Test 2: The evaluator shall try to modify all security related parameters for configuration of the handling of audit data with prior authentication as Security Administrator. The effects of the modifications should be confirmed. The term ‘handling of audit data’ refers to the different options for selection and assignments in SFRs FAU_STG_EXT.1.2, FAU_STG_EXT.1.3 and FAU_STG_EXT.2.
+.. Test 1: The evaluator shall try to modify all security related parameters for configuration of the handling of audit data without prior authentication as Security Administrator (by authentication as a user with no administrator privileges or without user authentication at all). Attempts to modify parameters without prior authentication should fail. According to the implementation no other users than the Security Administrator might be defined and without any user authentication the user might not be able to get to the point where the attempt can be executed. In that case it shall be demonstrated that access control mechanisms prevent execution up to the step that can be reached without authentication as Security Administrator. The term ‘handling of audit data’ refers to the different options for selection and assignments in SFRs FAU_STG_EXT.1.2/LocSpace, FAU_STG_EXT.1.3/LocSpace and FAU_STG_EXT.2.
+.. Test 2: The evaluator shall try to modify all security related parameters for configuration of the handling of audit data with prior authentication as Security Administrator. The effects of the modifications should be confirmed. The term ‘handling of audit data’ refers to the different options for selection and assignments in SFRs FAU_STG_EXT.1.2/LocSpace, FAU_STG_EXT.1.3/LocSpace and FAU_STG_EXT.2.
 +
 The evaluator does not necessarily have to test all possible values of the security related parameters for configuration of the handling of audit data but at least one allowed value per parameter.
 

--- a/ND_Supporting_Document_3_0.adoc
+++ b/ND_Supporting_Document_3_0.adoc
@@ -241,7 +241,7 @@ _Additional Note for Distributed TOEs_
 ===== Tests
 
 [arabic, start=48]
-. Testing of the trusted channel mechanism for audit will be performed as specified in the associated assurance activities for the particular trusted channel mechanism. 
+. Testing of secure transmission of the audit data externally (FTP_ITC.1) and, where applicable, intercomponent (FPT_ITT.1 or FTP_ITC.1) shall be performed according to the assurance activities for the particular protocol(s). 
 . The evaluator shall perform the following additional test for this requirement:
 [loweralpha]
 .. Test 1: The evaluator shall establish a session between the TOE and the audit server according to the configuration guidance provided. The evaluator shall then examine the traffic that passes between the audit server and the TOE during several activities of the evaluator’s choice designed to generate audit data to be transferred to the audit server. The evaluator shall observe that these data are not able to be viewed in the clear during this transfer, and that they are successfully received by the audit server. The evaluator shall record the particular software (name, version) used on the audit server during testing. The evaluator shall verify that the TOE is capable of transferring audit data to an external audit server automatically without administrator intervention.

--- a/ND_Supporting_Document_3_0.adoc
+++ b/ND_Supporting_Document_3_0.adoc
@@ -169,7 +169,7 @@ _Additional Note for Distributed TOEs_
 ==== FAU_GEN.1 Audit data generation
 
 [arabic, start=20]
-. The main reasons for collecting audit information are to detect and identify error conditions, security violations, etc. and to provide sufficient information to the Security Administrator to resolve the issue. The audit information to be collected according to FAU_GEN.1, and the failure conditions identified in tables 2, 4, and 5 need to enable the Security Administrator at least to detect and identify the problem and provide at least basic information to resolve the issue. Also for this level of detail, the other FAU requirements apply, in particular the need for local and remote storage of audit information according to FAU_STG_EXT.1/Remote.
+. The main reasons for collecting audit information are to detect and identify error conditions, security violations, etc. and to provide sufficient information to the Security Administrator to resolve the issue. The audit information to be collected according to FAU_GEN.1, and the failure conditions identified in tables 2, 4, and 5 need to enable the Security Administrator at least to detect and identify the problem and provide at least basic information to resolve the issue. Also for this level of detail, the other FAU requirements apply, in particular the need for local and remote storage of audit information according to FAU_STG_EXT.1.
 . The level of detail that needs to be provided to the Security Administrator to actually resolve an issue usually depends on the complexity of the underlying use case. It is expected that a product provides additional levels of auditing to support resolution of error conditions, security violations, etc. beyond the level required by FAU_GEN.1, but it should also be clear that a high level of granularity cannot be maintained on most systems by default due to the high number of audit events that would be generated in such a configuration. It is expected that the TOE will be capable of auditing sufficient information to meet the requirements of FAU_GEN.1. If the TOE allows configuration of the level of auditing without taking the TOE out of the evaluated configuration, some of the audit events required by FAU_GEN.1 may only be recorded after corresponding configuration of the audit functionality.
 . The issue described above explicitly refers to the use of X.509 certificates. In case a certificate-based authentication fails, an error message telling the Security Administrator that ‘something is wrong with the certificate’ shall not be considered as sufficient information about the ‘reason for failure’ as a basic information to resolve the issue. The log message will inform the Security Administrator of at least the following:
 
@@ -214,7 +214,7 @@ _Additional Note for Distributed TOEs_
 . This activity should be accomplished in conjunction with the testing of FAU_GEN.1.1.
 . For distributed TOEs the evaluator shall verify that where auditable events are instigated by another component, the component that records the event associates the event with the identity of the instigator. The evaluator shall perform at least one test on one component where another component instigates an auditable event. The evaluator shall verify that the event is recorded by the component as expected and the event is associated with the instigating component. It is assumed that an event instigated by another component can at least be generated for building up a secure channel between two TOE components. If for some reason (could be e.g. TSS or Guidance Documentation) the evaluator would come to the conclusion that the overall TOE does not generate any events instigated by other components, then this requirement shall be omitted.
 
-==== FAU_STG_EXT.1/Remote Protected audit event storage
+==== FAU_STG_EXT.1 Protected Audit Event Storage
 
 ===== TSS
 
@@ -223,60 +223,41 @@ _Additional Note for Distributed TOEs_
 . The evaluator shall examine the TSS to ensure it describes whether the TOE is a standalone TOE that stores audit data locally or a distributed TOE that stores audit data locally on each TOE component or a distributed TOE that contains TOE components that cannot store audit data locally on themselves but need to transfer audit data to other TOE components that can store audit data locally. The evaluator shall examine the TSS to ensure that for distributed TOEs it contains a list of TOE components that store audit data locally. The evaluator shall examine the TSS to ensure that for distributed TOEs that contain components which do not store audit data locally but transmit their generated audit data to other components it contains a mapping between the transmitting and storing TOE components.
 . The evaluator shall examine the TSS to ensure that it details whether the transmission of audit data to an external IT entity can be done in real-time, periodically, or both. In the case where the TOE is capable of performing transmission periodically, the evaluator needs to verify that the TSS provides details about what event stimulates the transmission to be made as well as the possible acceptable frequency for the transfer of audit data.
 . For distributed TOEs the evaluator shall examine the TSS to ensure it describes to which TOE components this SFR applies and how audit data transfer to the external audit server is implemented among the different TOE components (e.g. every TOE components does its own transfer or the data is sent to another TOE component for central transfer of all audit events to the external audit server).
-
+. The evaluator shall examine the TSS to ensure it describes the amount of audit data that can be stored locally and how these records are protected against unauthorized modification or deletion.
+. The evaluator shall examine the TSS to ensure it describes the method implemented for local logging, including format (e.g. buffer, log file, database) and whether the logs are persistent or non-persistent.
+. The evaluator shall examine the TSS to ensure it describes the conditions that must be met for authorized deletion of audit records.
+. The evaluator shall examine the TSS to ensure it details the behaviour of the TOE when the storage space for audit data is full. When the option ‘overwrite previous audit record’ is selected this description should include an outline of the rule for overwriting audit data. If ‘other actions’ are chosen such as sending the new audit data to an external IT entity, then the related behaviour of the TOE shall also be detailed in the TSS.
+. For distributed TOEs the evaluator shall examine the TSS to ensure it describes which TOE components are storing audit information locally and which components are buffering audit information and forwarding the information to another TOE component for local storage. For every component the TSS shall describe the behaviour when local storage space or buffer space is exhausted.
 
 ===== Guidance Documentation
 
-[arabic, start=38]
+[arabic, start=43]
 . The evaluator shall also examine the guidance documentation to ensure it describes how to establish the trusted channel to the audit server, as well as describe any requirements on the audit server (particular audit server protocol, version of the protocol required, etc.), as well as configuration of the TOE needed to communicate with the audit server.
-. The evaluator shall also examine the guidance documentation to determine that it describes the relationship between the local audit data and the audit data that are sent to the audit log server. For example, when an audit event is generated, is it simultaneously sent to the external server and the local store, or is the local store used as a buffer and “cleared” periodically by sending the data to the audit server.
-
+. The evaluator shall also examine the guidance documentation to ensure it describes the relationship between the local audit data and the audit data that are sent to the audit log server. For example, when an audit event is generated, is it simultaneously sent to the external server and the local store, or is the local store used as a buffer and “cleared” periodically by sending the data to the audit server.
+. The evaluator shall examine the guidance documentation to ensure it describes any configuration required for protection of the locally stored audit data against unauthorized modification or deletion.
+. If the storage size is configurable, the evaluator shall review the Guidance Documentation to ensure it contains instructions on specifying the required parameters.
+. If more than one selection is made for FAU_STG_EXT.1.5, the evaluator shall review the Guidance Documentation to ensure it contains instructions on specifying which action is performed when the local storage space is full.
 
 ===== Tests
 
-[arabic, start=40]
-. Testing of the trusted channel mechanism for audit will be performed as specified in the associated assurance activities for the particular trusted channel mechanism. The evaluator shall perform the following additional test for this requirement:
+[arabic, start=48]
+. Testing of the trusted channel mechanism for audit will be performed as specified in the associated assurance activities for the particular trusted channel mechanism. 
+. The evaluator shall perform the following additional test for this requirement:
 [loweralpha]
 .. Test 1: The evaluator shall establish a session between the TOE and the audit server according to the configuration guidance provided. The evaluator shall then examine the traffic that passes between the audit server and the TOE during several activities of the evaluator’s choice designed to generate audit data to be transferred to the audit server. The evaluator shall observe that these data are not able to be viewed in the clear during this transfer, and that they are successfully received by the audit server. The evaluator shall record the particular software (name, version) used on the audit server during testing. The evaluator shall verify that the TOE is capable of transferring audit data to an external audit server automatically without administrator intervention.
 .. Test 2: For distributed TOEs, Test 1 defined above shall be applicable to all TOE components that forward audit data to an external audit server.
-
-==== FAU_STG_EXT.1/LocSpace Local audit event storage
-
-===== TSS
-
-[arabic, start=41]
-. The evaluator shall examine the TSS to ensure it describes the amount of audit data that can be stored locally and how these records are protected against unauthorized modification or deletion.
-. The evaluator shall ensure that the TSS describes the method implemented for local logging, including format (e.g. buffer, log file, database) and whether the logs are persistent or non-persistent.
-. The evaluator shall ensure that the TSS describes the conditions that must be met for authorized deletion of audit records.
-. The evaluator shall examine the TSS to ensure that it details the behaviour of the TOE when the storage space for audit data is full. When the option ‘overwrite previous audit record’ is selected this description should include an outline of the rule for overwriting audit data. If ‘other actions’ are chosen such as sending the new audit data to an external IT entity, then the related behaviour of the TOE shall also be detailed in the TSS.
-. For distributed TOEs the evaluator shall examine the TSS to ensure it describes which TOE components are storing audit information locally and which components are buffering audit information and forwarding the information to another TOE component for local storage. For every component the TSS shall describe the behaviour when local storage space or buffer space is exhausted.
-
-
-===== Guidance Documentation
-
-[arabic, start=46]
-. The evaluator shall examine the guidance documentation to determine that it describes any configuration required for protection of the locally stored audit data against unauthorized modification or deletion.
-. If the storage size is configurable, the evaluator shall review the Guidance Documentation to ensure that it contains instructions on specifying the required parameters.
-. If more than one selection is made for FAU_STG_EXT.1.3/LocSpace, the evaluator shall review the Guidance Documentation to ensure that it contains instructions on specifying which action is performed when the local storage space is full
-
-
-===== Tests
-
-[arabic, start=49]
-. The evaluator shall perform the following tests:
-[loweralpha, start=1]
-.. Test 1: The evaluator shall perform operations that generate audit data and verify that this data is stored locally. The evaluator shall then make note of whether the TSS claims persistent or non-persistent logging and perform one of the following actions:
+.. Test 3: The evaluator shall perform operations that generate audit data and verify that this data is stored locally. The evaluator shall then make note of whether the TSS claims persistent or non-persistent logging and perform one of the following actions:
 [lowerroman]
 ... If persistent logging is selected, the evaluator shall perform a power cycle of the TOE and ensure that following power on operations the log events generated are still maintained within the local audit storage.
 ... If non-persistent logging is selected, the evaluator shall perform a power cycle of the TOE and ensure that following power on operations the log events generated are no longer present within the local audit storage.
-[loweralpha, start=3]
-.. Test 2: The evaluator shall perform operations that generate audit data until the local storage space is exceeded and verifies that the TOE complies with the behaviour defined in FAU_STG_EXT.1.3/LocSpace. Depending on the configuration this means that the evaluator has to check the content of the audit data when the audit data is just filled to the maximum and then verifies that:
-[lowerroman]
-...	The audit data remains unchanged with every new auditable event that should be tracked but that the audit data is recorded again after the local storage for audit data is cleared (for the option ‘drop new audit data’ in FAU_STG_EXT.1.3/LocSpace).
-... The existing audit data is overwritten with every new auditable event that should be tracked according to the specified rule (for the option ‘overwrite previous audit records’ in FAU_STG_EXT.1.3/LocSpace)
-...	The TOE behaves as specified (for the option ‘other action’ in FAU_STG_EXT.1.3/LocSpace).
 [loweralpha, start=4]
-.. Test 3: For distributed TOEs, for the local storage according to FAU_STG_EXT.1.2/LocSpace, Test 1 specified above shall be applied to all TOE components that store audit data locally. For all TOE components that store audit data locally and comply with FAU_STG_EXT.2, Test 2 specified above shall be applied. The evaluator shall verify that the transfer of audit data to an external audit server is implemented.
+.. Test 4: The evaluator shall perform operations that generate audit data until the local storage space is exceeded and verifies that the TOE complies with the behaviour defined in FAU_STG_EXT.1.5. Depending on the configuration this means that the evaluator has to check the content of the audit data when the audit data is just filled to the maximum and then verifies that:
+[lowerroman]
+...	The audit data remains unchanged with every new auditable event that should be tracked but that the audit data is recorded again after the local storage for audit data is cleared (for the option ‘drop new audit data’ in FAU_STG_EXT.1.5).
+... The existing audit data is overwritten with every new auditable event that should be tracked according to the specified rule (for the option ‘overwrite previous audit records’ in FAU_STG_EXT.1.5)
+...	The TOE behaves as specified (for the option ‘other action’ in FAU_STG_EXT.1.5).
+[loweralpha, start=5]
+.. Test 5: For distributed TOEs, for the local storage according to FAU_STG_EXT.1.4, Test 1 specified above shall be applied to all TOE components that store audit data locally. For all TOE components that store audit data locally and comply with FAU_STG_EXT.2, Test 2 specified above shall be applied. The evaluator shall verify that the transfer of audit data to an external audit server is implemented.
 
 === Cryptographic Support (FCS)
 
@@ -1058,7 +1039,7 @@ In the case where the TOE is able to detect when the cable is removed from the d
 ==== FAU_STG_EXT.2 Counting lost audit data
 
 [arabic, start=230]
-. This activity should be accomplished in conjunction with the testing of FAU_STG_EXT.1.2/LocSpace and FAU_STG_EXT.1.3/LocSpace.
+. This activity should be accomplished in conjunction with the testing of FAU_STG_EXT.1.4 and FAU_STG_EXT.1.5.
 
 ===== TSS
 
@@ -1075,13 +1056,13 @@ In the case where the TOE is able to detect when the cable is removed from the d
 ===== Tests
 
 [arabic, start=235]
-. The evaluator shall verify that the numbers provided by the TOE according to the selection for FAU_STG_EXT.2 are correct when performing the tests for FAU_STG_EXT.1.3/LocSpace.
+. The evaluator shall verify that the numbers provided by the TOE according to the selection for FAU_STG_EXT.2 are correct when performing the tests for FAU_STG_EXT.1.5.
 . For distributed TOEs the evaluator shall verify the correct implementation of counting of lost audit data for all TOE components that are supporting this feature according to the description in the TSS.
 
 ==== FAU_STG_EXT.3 Action in case of possible audit data loss
 
 [arabic, start=237]
-. This activity should be accomplished in conjunction with the testing of FAU_STG_EXT.1.2/LocSpace and FAU_STG_EXT.1.3/LocSpace.
+. This activity should be accomplished in conjunction with the testing of FAU_STG_EXT.1.4 and FAU_STG_EXT.1.5.
 
 ===== TSS
 
@@ -3043,8 +3024,8 @@ The evaluator does not have to test all possible values of the security related 
 [arabic, start=605]
 . The evaluator shall perform the following tests:
 
-.. Test 1: The evaluator shall try to modify all security related parameters for configuration of the handling of audit data without prior authentication as Security Administrator (by authentication as a user with no administrator privileges or without user authentication at all). Attempts to modify parameters without prior authentication should fail. According to the implementation no other users than the Security Administrator might be defined and without any user authentication the user might not be able to get to the point where the attempt can be executed. In that case it shall be demonstrated that access control mechanisms prevent execution up to the step that can be reached without authentication as Security Administrator. The term ‘handling of audit data’ refers to the different options for selection and assignments in SFRs FAU_STG_EXT.1.2/LocSpace, FAU_STG_EXT.1.3/LocSpace and FAU_STG_EXT.2.
-.. Test 2: The evaluator shall try to modify all security related parameters for configuration of the handling of audit data with prior authentication as Security Administrator. The effects of the modifications should be confirmed. The term ‘handling of audit data’ refers to the different options for selection and assignments in SFRs FAU_STG_EXT.1.2/LocSpace, FAU_STG_EXT.1.3/LocSpace and FAU_STG_EXT.2.
+.. Test 1: The evaluator shall try to modify all security related parameters for configuration of the handling of audit data without prior authentication as Security Administrator (by authentication as a user with no administrator privileges or without user authentication at all). Attempts to modify parameters without prior authentication should fail. According to the implementation no other users than the Security Administrator might be defined and without any user authentication the user might not be able to get to the point where the attempt can be executed. In that case it shall be demonstrated that access control mechanisms prevent execution up to the step that can be reached without authentication as Security Administrator. The term ‘handling of audit data’ refers to the different options for selection and assignments in SFRs FAU_STG_EXT.1.4, FAU_STG_EXT.1.5 and FAU_STG_EXT.2.
+.. Test 2: The evaluator shall try to modify all security related parameters for configuration of the handling of audit data with prior authentication as Security Administrator. The effects of the modifications should be confirmed. The term ‘handling of audit data’ refers to the different options for selection and assignments in SFRs FAU_STG_EXT.1.4, FAU_STG_EXT.1.5 and FAU_STG_EXT.2.
 +
 The evaluator does not necessarily have to test all possible values of the security related parameters for configuration of the handling of audit data but at least one allowed value per parameter.
 

--- a/NDcPP_v3_0.adoc
+++ b/NDcPP_v3_0.adoc
@@ -368,7 +368,7 @@ Table 1 specifies how each of the SFRs in this cPP must be met, using the catego
 |FAU_GEN.1 |Audit Data Generation |All
 |FAU_GEN.2 |User Identity Association |All
 |FAU_GEN_EXT.1 |Security Audit Data Generation for Distributed TOE component |All
-|FAU_STG_EXT.1 |Protected Audit Event Storage |All
+|FAU_STG_EXT.1/Remote |Protected Audit Event Storage |All
 |FAU_STG_EXT.1/LocSpace | Local Audit Event Storage |Feature Dependent
 |FAU_STG.1 |Protected Audit Trail Storage |Feature Dependent
 |FAU_STG_EXT.2 |Counting Lost Audit Data |Feature Dependent
@@ -526,7 +526,7 @@ SFR Rationale:
 
 * Requirements for basic auditing capabilities are specified in FAU_GEN.1 and FAU_GEN.2, with timestamps provided according to FPT_STM_EXT.1 and if applicable, protection of NTP channels in FCS_NTP_EXT.1
 * Requirements for protecting audit records stored on the TOE are specified in FAU_STG.1
-* Requirements for secure storage and transmission of local audit records to an external IT entity via a secure channel are specified in FAU_STG_EXT.1 and FAU_STG_EXT.1/LocSpace
+* Requirements for secure storage and transmission of local audit records to an external IT entity via a secure channel are specified in FAU_STG_EXT.1/Remote and FAU_STG_EXT.1/LocSpace
 * Optional additional requirements for dealing with potential loss of locally stored audit records are specified in FAU_STG_EXT.2, and FAU_STG_EXT.3
 * If (optionally) configuration of the audit functionality is provided by the TOE then this is specified in FMT_SMF.1 and confining this functionality to Security Administrators is required by FMT_MOF.1/Functions.
 
@@ -826,7 +826,7 @@ _The date and time information for any audit event shall be recorded as part of 
 |*Requirement* |*Auditable Events* |*Additional Audit Record Contents*
 |FAU_GEN.1 |None. |None.
 |FAU_GEN.2 |None. |None.
-|FAU_STG_EXT.1 |None. |None.
+|FAU_STG_EXT.1/Remote |None. |None.
 |FAU_STG_EXT.1/LocSpace |Configuration of local audit settings. |Identity of account making changes to the audit configuration.
 |FCS_CKM.1 |None. |None.
 |FCS_CKM.2 |None. |None.
@@ -888,11 +888,11 @@ _Where an auditable event is triggered by another component, the component that 
 
 A Network Device TOE is not expected to take responsibility for all audit storage itself. Although it is required to store data locally at the time of generation, and to take some appropriate action if this local storage capacity is exceeded, the TOE is also required to be able to establish a secure link to an external audit server to enable external audit trail storage.
 
-===== FAU_STG_EXT.1 Protected Audit Event Storage
+===== FAU_STG_EXT.1/Remote Protected Audit Event Storage
 
-*FAU_STG_EXT.1 Protected Audit Event Storage*
+*FAU_STG_EXT.1/Remote Protected Audit Event Storage*
 
-*FAU_STG_EXT.1.1* The TSF shall be able to transmit the generated audit data to an external IT entity using a trusted channel according to FTP_ITC.1.
+*FAU_STG_EXT.1.1/Remote* The TSF shall be able to transmit the generated audit data to an external IT entity using a trusted channel according to FTP_ITC.1.
 
 *_Application Note {counter:appnote_count}_*
 
@@ -902,7 +902,7 @@ _For distributed TOEs, each component must be able to export audit data across a
 
 _An ‘external IT entity’ (physical or virtualized) is another device or computer on the network in which the TOE no longer has access to the audit records. This can be a physical or virtualized entity._
 
-*FAU_STG_EXT.1.2* The TSF shall be able to store generated audit data on the TOE itself. In addition [selection:
+*FAU_STG_EXT.1.2/Remote* The TSF shall be able to store generated audit data on the TOE itself. In addition [selection:
 
 * _The TOE shall consist of a single standalone component that stores audit data locally,_
 * _The TOE shall be a distributed TOE that stores audit data on the following TOE components: [assignment: identification of TOE components],_
@@ -1643,7 +1643,7 @@ The local storage space for audit data of a Network Device is also limited, and 
 
 *FAU_STG_EXT.2 Counting Lost Audit Data*
 
-*FAU_STG_EXT.2.1* The TSF shall provide information about the number of [selection: _dropped, overwritten, [assignment: other information]_] audit records in the case where the local storage has been filled and the TSF takes one of the actions defined in FAU_STG_EXT.1.3.
+*FAU_STG_EXT.2.1* The TSF shall provide information about the number of [selection: _dropped, overwritten, [assignment: other information]_] audit records in the case where the local storage has been filled and the TSF takes one of the actions defined in FAU_STG_EXT.1.3/LocSpace.
 
 *_Application Note {counter:appnote_count}_*
 
@@ -2150,7 +2150,7 @@ This SFR needs to be added to the ST for evaluation of distributed TOEs which co
 
 *_Application Note {counter:appnote_count}_*
 
-_If a component of a distributed TOE collects data from other components and then forwards it to another component or external IT entity (cf. FAU_STG_EXT.1.1) then the operations in this SFR must be performed in a way to cover the storage space action(s) for all of the audit data that the TOE collects (i.e. not just for the data generated by the collecting component for itself)._
+_If a component of a distributed TOE collects data from other components and then forwards it to another component or external IT entity (cf. FAU_STG_EXT.1.1/Remote) then the operations in this SFR must be performed in a way to cover the storage space action(s) for all of the audit data that the TOE collects (i.e. not just for the data generated by the collecting component for itself)._
 
 _It is acceptable for a TOE component to store audit information in multiple places (e.g. for redundancy), whether locally in the TOE component itself and in another TOE component, or in more than one other TOE component._
 
@@ -2166,7 +2166,7 @@ This SFR needs to be added to the ST for evaluation of distributed TOEs which co
 
 *_Application Note {counter:appnote_count}_*
 
-_If a component of a distributed TOE collects data from other components and then forwards it to another component or external IT entity (cf. FAU_STG_EXT.1.1) then the operations in this SFR must be performed in a way to cover the storage space action(s) for all of the audit data that the TOE collects (i.e. not just for the data generated by the collecting component for itself)._
+_If a component of a distributed TOE collects data from other components and then forwards it to another component or external IT entity (cf. FAU_STG_EXT.1.1/Remote) then the operations in this SFR must be performed in a way to cover the storage space action(s) for all of the audit data that the TOE collects (i.e. not just for the data generated by the collecting component for itself)._
 
 _It is acceptable for a TOE component to store audit information in multiple places (e.g. for redundancy), whether locally in the TOE component itself and in another TOE component, or in more than one other TOE component._
 
@@ -3147,8 +3147,8 @@ _FMT_MOF.1/AutoUpdate is only applicable and should be included if the TOE suppo
 
 _FMT_MOF.1/Functions should be chosen if one or more of the following scenarios apply:_
 
-* _If the transmission protocol for transmission of audit data to an external IT entity as defined in FAU_STG_EXT.1.1 is configurable, “transmission of audit data to an external IT entity” shall be chosen._
-* _If the handling of audit data is configurable, “handling of audit data” must be chosen. The term “handling of audit data” refers to the different options for selection and assignments in SFRs FAU_STG_EXT.1.3 and FAU_STG_EXT.2._
+* _If the transmission protocol for transmission of audit data to an external IT entity as defined in FAU_STG_EXT.1.1/Remote is configurable, “transmission of audit data to an external IT entity” shall be chosen._
+* _If the handling of audit data is configurable, “handling of audit data” must be chosen. The term “handling of audit data” refers to any administratively configurable selection or assignments in any FAU_STG_EXT.x SFR._
 * _If the behaviour of the audit functionality is configurable when Local Audit Storage Space is full, “audit functionality when Local Audit Storage Space is full” must be chosen._
 
 _The first selection for ‘determine the behaviour of’ and ‘modify the behaviour of’ should be done as appropriate. It might be necessary to have different selections for the first selection depending on the second selection (e.g. “handling of audit data” might require “determine the behaviour of” and “modify the behaviour of” for the first selection on the one hand and “audit functionality when Local Audit Storage Space is full” might require “modify the behaviour of” only). In that case_ _FMT_MOF.1/Functions should be iterated with increasing number appended (i.e. FMT_MOF.1/Functions1, FMT_MOF.1/Functions2, etc.)._
@@ -3262,9 +3262,9 @@ The following actions should be auditable if FAU_GEN Security audit data generat
 [loweralpha]
 . No audit necessary.
 
-=====  FAU_STG_EXT.1 Protected Audit Event Storage
+=====  FAU_STG_EXT.1/Remote Protected Audit Event Storage
 
-*FAU_STG_EXT.1 Protected Audit Event Storage*
+*FAU_STG_EXT.1/Remote Protected Audit Event Storage*
 
 Hierarchical to: No other components.
 
@@ -3273,15 +3273,13 @@ Dependencies:
 * FAU_GEN.1 Audit data generation
 * FTP_ITC.1 Inter-TSF Trusted Channel
 
-*FAU_STG_EXT.1.1* The TSF shall be able to transmit the generated audit data to an external IT entity using a trusted channel according to FTP_ITC.1
+*FAU_STG_EXT.1.1/Remote* The TSF shall be able to transmit the generated audit data to an external IT entity using a trusted channel according to FTP_ITC.1
 
-*FAU_STG_EXT.1.2* The TSF shall be able to store generated audit data on the TOE itself. In addition [selection:
+*FAU_STG_EXT.1.2/Remote* The TSF shall be able to store generated audit data on the TOE itself. In addition [selection:
 
 * _The TOE shall consist of a single standalone component that stores audit data locally,_
 * _The TOE shall be a distributed TOE that stores audit data on the following TOE components: [assignment: identification of TOE components],_
 * _The TOE shall be a distributed TOE with storage of audit data provided externally for the following TOE components: [assignment: list of TOE components that do not store audit data locally and the other TOE components to which they transmit their generated audit data]_.
-
-*FAU_STG_EXT.1.3* The TSF shall [selection: _drop new audit data, overwrite previous audit records according to the following rule: [assignment: rule for overwriting previous audit records], [assignment: other action]_] when the local storage space for audit data is full.
 
 =====  FAU_STG_EXT.1/LocSpace Local Audit Event Storage
 
@@ -3292,7 +3290,7 @@ Hierarchical to: No other components.
 Dependencies:
 
 * FAU_GEN.1 Audit data generation
-* FAU_STG_EXT.1 Protected Audit Event Storage
+* FAU_STG_EXT.1/Remote Protected Audit Event Storage
 
 *FAU_STG_EXT.1.1/LocSpace* The TSF shall maintain a [_selection: log file, database, buffer, [assignment:other local logging method]_] of audit records in the event that an interruption of communication with the remote syslog server occurs.
 
@@ -3309,9 +3307,9 @@ Hierarchical to: No other components.
 Dependencies:
 
 * FAU_GEN.1 Audit data generation
-* FAU_STG_EXT.1 External Audit Trail Storage
+* FAU_STG_EXT.1/Remote External Audit Trail Storage
 
-*FAU_STG_EXT.2.1* The TSF shall provide information about the number of [selection: _dropped, overwritten, [assignment: other information]_] audit records in the case where the local storage has been filled and the TSF takes one of the actions defined in FAU_STG_EXT.1.3.
+*FAU_STG_EXT.2.1* The TSF shall provide information about the number of [selection: _dropped, overwritten, [assignment: other information]_] audit records in the case where the local storage has been filled and the TSF takes one of the actions defined in FAU_STG_EXT.1.3/LocSpace.
 
 =====  FAU_STG_EXT.3 Action in Case of Possible Audit Data Loss
 
@@ -3322,7 +3320,7 @@ Hierarchical to: No other components.
 Dependencies:
 
 * FAU_GEN.1 Audit data generation
-* FAU_STG_EXT.1 External Audit Trail Storage
+* FAU_STG_EXT.1/Remote External Audit Trail Storage
 
 *FAU_STG_EXT.3.1* The TSF shall generate a warning to inform the Administrator before the audit trail exceeds the local audit trail storage capacity.
 
@@ -4732,7 +4730,7 @@ FAU_GEN.1 included
 
 Satisfied by FIA_UIA_EXT.1, which specifies the relevant Administrator identification timing
 
-|FAU_STG_EXT.1 a|
+|FAU_STG_EXT.1/Remote a|
 FAU_GEN.1
 
 FTP_ITC.1
@@ -4745,9 +4743,9 @@ FTP_ITC.1 included
 |FAU_STG_EXT.1/LocSpace a|
 FAU_GEN.1
 
-FAU_STG_EXT.1
+FAU_STG_EXT.1/Remote
 
-|FAU_GEN.1 & FAU_STG_EXT.1 included
+|FAU_GEN.1 & FAU_STG_EXT.1/Remote included
 |FCS_CKM.1 a|
 FCS_CKM.2 or FCS_COP.1
 
@@ -4852,9 +4850,9 @@ FMT_SMF.1 included
 |FAU_STG_EXT.2 a|
 FAU_GEN.1
 
-FAU_STG_EXT.1
+FAU_STG_EXT.1/Remote
 
-|FAU_GEN.1 & FAU_STG_EXT.1 included
+|FAU_GEN.1 & FAU_STG_EXT.1/Remote included
 |FAU_STG_EXT.3 |FAU_STG.1 |FAU_STG.1 included as optional SFR
 |FIA_X509_EXT.1/ITT |FIA_X509_EXT.2 |FIA_X509_EXT.2 (selection-based SFR) included
 |FPT_ITT.1 |None |

--- a/NDcPP_v3_0.adoc
+++ b/NDcPP_v3_0.adoc
@@ -368,8 +368,7 @@ Table 1 specifies how each of the SFRs in this cPP must be met, using the catego
 |FAU_GEN.1 |Audit Data Generation |All
 |FAU_GEN.2 |User Identity Association |All
 |FAU_GEN_EXT.1 |Security Audit Data Generation for Distributed TOE component |All
-|FAU_STG_EXT.1/Remote |Protected Audit Event Storage |All
-|FAU_STG_EXT.1/LocSpace | Local Audit Event Storage |Feature Dependent
+|FAU_STG_EXT.1 |Protected Audit Event Storage |All
 |FAU_STG.1 |Protected Audit Trail Storage |Feature Dependent
 |FAU_STG_EXT.2 |Counting Lost Audit Data |Feature Dependent
 |FAU_STG_EXT.3 |Display warning for local storage space |Feature Dependent
@@ -524,10 +523,10 @@ Threat agents may attempt to access, change, and/or modify the security function
 
 SFR Rationale:
 
-* Requirements for basic auditing capabilities are specified in FAU_GEN.1 and FAU_GEN.2, with timestamps provided according to FPT_STM_EXT.1 and if applicable, protection of NTP channels in FCS_NTP_EXT.1
-* Requirements for protecting audit records stored on the TOE are specified in FAU_STG.1
-* Requirements for secure storage and transmission of local audit records to an external IT entity via a secure channel are specified in FAU_STG_EXT.1/Remote and FAU_STG_EXT.1/LocSpace
-* Optional additional requirements for dealing with potential loss of locally stored audit records are specified in FAU_STG_EXT.2, and FAU_STG_EXT.3
+* Requirements for basic auditing capabilities are specified in FAU_GEN.1 and FAU_GEN.2, with timestamps provided according to FPT_STM_EXT.1 and if applicable, protection of NTP channels in FCS_NTP_EXT.1.
+* Requirements for protecting audit records stored on the TOE are specified in FAU_STG.1.
+* Requirements for secure storage and transmission of local audit records to an external IT entity via a secure channel are specified in FAU_STG_EXT.1/Remote and FAU_STG_EXT.1.
+* Optional additional requirements for dealing with potential loss of locally stored audit records are specified in FAU_STG_EXT.2, and FAU_STG_EXT.3.
 * If (optionally) configuration of the audit functionality is provided by the TOE then this is specified in FMT_SMF.1 and confining this functionality to Security Administrators is required by FMT_MOF.1/Functions.
 
 ==== Administrator and Device Credentials and Data
@@ -826,8 +825,7 @@ _The date and time information for any audit event shall be recorded as part of 
 |*Requirement* |*Auditable Events* |*Additional Audit Record Contents*
 |FAU_GEN.1 |None. |None.
 |FAU_GEN.2 |None. |None.
-|FAU_STG_EXT.1/Remote |None. |None.
-|FAU_STG_EXT.1/LocSpace |Configuration of local audit settings. |Identity of account making changes to the audit configuration.
+|FAU_STG_EXT.1 |Configuration of local audit settings. |Identity of account making changes to the audit configuration.
 |FCS_CKM.1 |None. |None.
 |FCS_CKM.2 |None. |None.
 |FCS_CKM.4 |None. |None.
@@ -888,11 +886,11 @@ _Where an auditable event is triggered by another component, the component that 
 
 A Network Device TOE is not expected to take responsibility for all audit storage itself. Although it is required to store data locally at the time of generation, and to take some appropriate action if this local storage capacity is exceeded, the TOE is also required to be able to establish a secure link to an external audit server to enable external audit trail storage.
 
-===== FAU_STG_EXT.1/Remote Protected Audit Event Storage
+===== FAU_STG_EXT.1 Protected Audit Event Storage
 
-*FAU_STG_EXT.1/Remote Protected Audit Event Storage*
+*FAU_STG_EXT.1 Protected Audit Event Storage*
 
-*FAU_STG_EXT.1.1/Remote* The TSF shall be able to transmit the generated audit data to an external IT entity using a trusted channel according to FTP_ITC.1.
+*FAU_STG_EXT.1.1* The TSF shall be able to transmit the generated audit data to an external IT entity using a trusted channel according to FTP_ITC.1.
 
 *_Application Note {counter:appnote_count}_*
 
@@ -902,7 +900,7 @@ _For distributed TOEs, each component must be able to export audit data across a
 
 _An ‘external IT entity’ (physical or virtualized) is another device or computer on the network in which the TOE no longer has access to the audit records. This can be a physical or virtualized entity._
 
-*FAU_STG_EXT.1.2/Remote* The TSF shall be able to store generated audit data on the TOE itself. In addition [selection:
+*FAU_STG_EXT.1.2* The TSF shall be able to store generated audit data on the TOE itself. In addition [selection:
 
 * _The TOE shall consist of a single standalone component that stores audit data locally,_
 * _The TOE shall be a distributed TOE that stores audit data on the following TOE components: [assignment: identification of TOE components],_
@@ -922,23 +920,21 @@ _For pNDs, ‘on the TOE itself’ or ‘locally’ means on storage inside or d
 
 _For vNDs, local storage is any storage accessible by TOE software. In a virtualized environment, ‘local’ storage is under the control of the VS and may be physically located on the local host, but it could also be located on a network drive or storage array._
 
-===== FAU_STG_EXT.1/LocSpace Local Audit Event Storage
+*FAU_STG_EXT.1.3* The TSF shall maintain a [_selection: log file, database, buffer, [assignment:other local logging method]_] of audit records in the event that an interruption of communication with the remote syslog server occurs.
 
-*FAU_STG_EXT.1/LocSpace Local Audit Event Storage*
-
-*FAU_STG_EXT.1.1/LocSpace* The TSF shall maintain a [_selection: log file, database, buffer, [assignment:other local logging method]_] of audit records in the event that an interruption of communication with the remote syslog server occurs.
-
-*FAU_STG_EXT.1.2/LocSpace* The TSF shall be able to store [_selection: persistent, non-persistent_] audit records locally with a minimum storage size of [_assignment: number of records and/or file/buffer size(s)_].
+*FAU_STG_EXT.1.4* The TSF shall be able to store [_selection: persistent, non-persistent_] audit records locally with a minimum storage size of [_assignment: number of records and/or file/buffer size(s)_].
 
 *_Application Note {counter:appnote_count}_*
 
 _Persistent logging is defined as any record(s) that are retained through power off, power failure, or reboot. This requirement allows for the TSF to implement logging either persistent log records or non-persistent log records that may be cleared on reboot of the TOE._
 
-*FAU_STG_EXT.1.3/LocSpace* The TSF shall [_selection: drop new audit data, overwrite previous audit records according to the following rule: [assignment: rule for overwriting previous audit records], [assignment: other action]_] when the local storage space for audit data is full.
+*FAU_STG_EXT.1.5* The TSF shall [_selection: drop new audit data, overwrite previous audit records according to the following rule: [assignment: rule for overwriting previous audit records], [assignment: other action]_] when the local storage space for audit data is full.
 
 *_Application Note {counter:appnote_count}_*
 
 _The ST author may use the "other action" assignment to describe other measurable behavior (e.g. frequency of log file rotation based on size and/or age of log files)._
+
+_For distributed TOEs each component is not required to store generated audit data locally, but the overall TOE needs to be able to store audit data locally. Each component must at least provide the ability to temporarily buffer audit information locally to ensure that audit records are preserved in case of network connectivity issues. Buffering audit information locally, does not necessarily involve non-volatile memory: audit information could be buffered in volatile memory. However, the local storage of audit information in the sense of FAU_STG_EXT.1.5 needs to be done in non-volatile memory. For every component which performs local storage of audit information, the behaviour when local storage is exhausted needs to be described. For every component which is buffering audit information instead of storing audit information locally itself, it needs to be described what happens in case the buffer space is exhausted._
 
 === Cryptographic Support (FCS)
 
@@ -1643,7 +1639,7 @@ The local storage space for audit data of a Network Device is also limited, and 
 
 *FAU_STG_EXT.2 Counting Lost Audit Data*
 
-*FAU_STG_EXT.2.1* The TSF shall provide information about the number of [selection: _dropped, overwritten, [assignment: other information]_] audit records in the case where the local storage has been filled and the TSF takes one of the actions defined in FAU_STG_EXT.1.3/LocSpace.
+*FAU_STG_EXT.2.1* The TSF shall provide information about the number of [selection: _dropped, overwritten, [assignment: other information]_] audit records in the case where the local storage has been filled and the TSF takes one of the actions defined in FAU_STG_EXT.1.5.
 
 *_Application Note {counter:appnote_count}_*
 
@@ -2150,7 +2146,7 @@ This SFR needs to be added to the ST for evaluation of distributed TOEs which co
 
 *_Application Note {counter:appnote_count}_*
 
-_If a component of a distributed TOE collects data from other components and then forwards it to another component or external IT entity (cf. FAU_STG_EXT.1.1/Remote) then the operations in this SFR must be performed in a way to cover the storage space action(s) for all of the audit data that the TOE collects (i.e. not just for the data generated by the collecting component for itself)._
+_If a component of a distributed TOE collects data from other components and then forwards it to another component or external IT entity (cf. FAU_STG_EXT.1.1) then the operations in this SFR must be performed in a way to cover the storage space action(s) for all of the audit data that the TOE collects (i.e. not just for the data generated by the collecting component for itself)._
 
 _It is acceptable for a TOE component to store audit information in multiple places (e.g. for redundancy), whether locally in the TOE component itself and in another TOE component, or in more than one other TOE component._
 
@@ -2166,7 +2162,7 @@ This SFR needs to be added to the ST for evaluation of distributed TOEs which co
 
 *_Application Note {counter:appnote_count}_*
 
-_If a component of a distributed TOE collects data from other components and then forwards it to another component or external IT entity (cf. FAU_STG_EXT.1.1/Remote) then the operations in this SFR must be performed in a way to cover the storage space action(s) for all of the audit data that the TOE collects (i.e. not just for the data generated by the collecting component for itself)._
+_If a component of a distributed TOE collects data from other components and then forwards it to another component or external IT entity (cf. FAU_STG_EXT.1.1) then the operations in this SFR must be performed in a way to cover the storage space action(s) for all of the audit data that the TOE collects (i.e. not just for the data generated by the collecting component for itself)._
 
 _It is acceptable for a TOE component to store audit information in multiple places (e.g. for redundancy), whether locally in the TOE component itself and in another TOE component, or in more than one other TOE component._
 
@@ -3147,7 +3143,7 @@ _FMT_MOF.1/AutoUpdate is only applicable and should be included if the TOE suppo
 
 _FMT_MOF.1/Functions should be chosen if one or more of the following scenarios apply:_
 
-* _If the transmission protocol for transmission of audit data to an external IT entity as defined in FAU_STG_EXT.1.1/Remote is configurable, “transmission of audit data to an external IT entity” shall be chosen._
+* _If the transmission protocol for transmission of audit data to an external IT entity as defined in FAU_STG_EXT.1.1 is configurable, “transmission of audit data to an external IT entity” shall be chosen._
 * _If the handling of audit data is configurable, “handling of audit data” must be chosen. The term “handling of audit data” refers to any administratively configurable selection or assignments in any FAU_STG_EXT.x SFR._
 * _If the behaviour of the audit functionality is configurable when Local Audit Storage Space is full, “audit functionality when Local Audit Storage Space is full” must be chosen._
 
@@ -3262,9 +3258,9 @@ The following actions should be auditable if FAU_GEN Security audit data generat
 [loweralpha]
 . No audit necessary.
 
-=====  FAU_STG_EXT.1/Remote Protected Audit Event Storage
+=====  FAU_STG_EXT.1 Protected Audit Event Storage
 
-*FAU_STG_EXT.1/Remote Protected Audit Event Storage*
+*FAU_STG_EXT.1 Protected Audit Event Storage*
 
 Hierarchical to: No other components.
 
@@ -3273,30 +3269,19 @@ Dependencies:
 * FAU_GEN.1 Audit data generation
 * FTP_ITC.1 Inter-TSF Trusted Channel
 
-*FAU_STG_EXT.1.1/Remote* The TSF shall be able to transmit the generated audit data to an external IT entity using a trusted channel according to FTP_ITC.1
+*FAU_STG_EXT.1.1* The TSF shall be able to transmit the generated audit data to an external IT entity using a trusted channel according to FTP_ITC.1
 
-*FAU_STG_EXT.1.2/Remote* The TSF shall be able to store generated audit data on the TOE itself. In addition [selection:
+*FAU_STG_EXT.1.2* The TSF shall be able to store generated audit data on the TOE itself. In addition [selection:
 
 * _The TOE shall consist of a single standalone component that stores audit data locally,_
 * _The TOE shall be a distributed TOE that stores audit data on the following TOE components: [assignment: identification of TOE components],_
 * _The TOE shall be a distributed TOE with storage of audit data provided externally for the following TOE components: [assignment: list of TOE components that do not store audit data locally and the other TOE components to which they transmit their generated audit data]_.
 
-=====  FAU_STG_EXT.1/LocSpace Local Audit Event Storage
+*FAU_STG_EXT.1.3* The TSF shall maintain a [_selection: log file, database, buffer, [assignment:other local logging method]_] of audit records in the event that an interruption of communication with the remote syslog server occurs.
 
-*FAU_STG_EXT.1/LocSpace Local Audit Event Storage*
+*FAU_STG_EXT.1.4* The TSF shall be able to store [_selection: persistent, non-persistent_] audit records locally with a minimum storage size of [_assignment: number of records, file/buffer size(s)_].
 
-Hierarchical to: No other components.
-
-Dependencies:
-
-* FAU_GEN.1 Audit data generation
-* FAU_STG_EXT.1/Remote Protected Audit Event Storage
-
-*FAU_STG_EXT.1.1/LocSpace* The TSF shall maintain a [_selection: log file, database, buffer, [assignment:other local logging method]_] of audit records in the event that an interruption of communication with the remote syslog server occurs.
-
-*FAU_STG_EXT.1.2/LocSpace* The TSF shall be able to store [_selection: persistent, non-persistent_] audit records locally with a minimum storage size of [_assignment: number of records, file/buffer size(s)_].
-
-*FAU_STG_EXT.1.3/LocSpace* The TSF shall [_selection: drop new audit data, overwrite previous audit records according to the following rule: [assignment: rule for overwriting previous audit records], [assignment: other action]_] when the local storage space for audit data is full.
+*FAU_STG_EXT.1.5* The TSF shall [_selection: drop new audit data, overwrite previous audit records according to the following rule: [assignment: rule for overwriting previous audit records], [assignment: other action]_] when the local storage space for audit data is full.
 
 =====  FAU_STG_EXT.2 Counting Lost Audit Data
 
@@ -3307,9 +3292,9 @@ Hierarchical to: No other components.
 Dependencies:
 
 * FAU_GEN.1 Audit data generation
-* FAU_STG_EXT.1/Remote External Audit Trail Storage
+* FAU_STG_EXT.1 Protected Audit Event Storage
 
-*FAU_STG_EXT.2.1* The TSF shall provide information about the number of [selection: _dropped, overwritten, [assignment: other information]_] audit records in the case where the local storage has been filled and the TSF takes one of the actions defined in FAU_STG_EXT.1.3/LocSpace.
+*FAU_STG_EXT.2.1* The TSF shall provide information about the number of [selection: _dropped, overwritten, [assignment: other information]_] audit records in the case where the local storage has been filled and the TSF takes one of the actions defined in FAU_STG_EXT.1.5.
 
 =====  FAU_STG_EXT.3 Action in Case of Possible Audit Data Loss
 
@@ -3320,7 +3305,7 @@ Hierarchical to: No other components.
 Dependencies:
 
 * FAU_GEN.1 Audit data generation
-* FAU_STG_EXT.1/Remote External Audit Trail Storage
+* FAU_STG_EXT.1 Protected Audit Event Storage
 
 *FAU_STG_EXT.3.1* The TSF shall generate a warning to inform the Administrator before the audit trail exceeds the local audit trail storage capacity.
 
@@ -4730,7 +4715,7 @@ FAU_GEN.1 included
 
 Satisfied by FIA_UIA_EXT.1, which specifies the relevant Administrator identification timing
 
-|FAU_STG_EXT.1/Remote a|
+|FAU_STG_EXT.1 a|
 FAU_GEN.1
 
 FTP_ITC.1
@@ -4740,12 +4725,6 @@ FAU_GEN.1 included
 
 FTP_ITC.1 included
 
-|FAU_STG_EXT.1/LocSpace a|
-FAU_GEN.1
-
-FAU_STG_EXT.1/Remote
-
-|FAU_GEN.1 & FAU_STG_EXT.1/Remote included
 |FCS_CKM.1 a|
 FCS_CKM.2 or FCS_COP.1
 
@@ -4850,9 +4829,9 @@ FMT_SMF.1 included
 |FAU_STG_EXT.2 a|
 FAU_GEN.1
 
-FAU_STG_EXT.1/Remote
+FAU_STG_EXT.1
 
-|FAU_GEN.1 & FAU_STG_EXT.1/Remote included
+|FAU_GEN.1 & FAU_STG_EXT.1 included
 |FAU_STG_EXT.3 |FAU_STG.1 |FAU_STG.1 included as optional SFR
 |FIA_X509_EXT.1/ITT |FIA_X509_EXT.2 |FIA_X509_EXT.2 (selection-based SFR) included
 |FPT_ITT.1 |None |

--- a/NDcPP_v3_0.adoc
+++ b/NDcPP_v3_0.adoc
@@ -920,7 +920,7 @@ _For pNDs, ‘on the TOE itself’ or ‘locally’ means on storage inside or d
 
 _For vNDs, local storage is any storage accessible by TOE software. In a virtualized environment, ‘local’ storage is under the control of the VS and may be physically located on the local host, but it could also be located on a network drive or storage array._
 
-*FAU_STG_EXT.1.3* The TSF shall maintain a [_selection: log file, database, buffer, [assignment:other local logging method]_] of audit records in the event that an interruption of communication with the remote syslog server occurs.
+*FAU_STG_EXT.1.3* The TSF shall maintain a [_selection: log file, database, buffer, [assignment:other local logging method]_] of audit records in the event that an interruption of communication with the remote audit server occurs.
 
 *FAU_STG_EXT.1.4* The TSF shall be able to store [_selection: persistent, non-persistent_] audit records locally with a minimum storage size of [_assignment: number of records and/or file/buffer size(s)_].
 
@@ -3279,7 +3279,7 @@ Dependencies:
 * _The TOE shall be a distributed TOE that stores audit data on the following TOE components: [assignment: identification of TOE components],_
 * _The TOE shall be a distributed TOE with storage of audit data provided externally for the following TOE components: [assignment: list of TOE components that do not store audit data locally and the other TOE components to which they transmit their generated audit data]_.
 
-*FAU_STG_EXT.1.3* The TSF shall maintain a [_selection: log file, database, buffer, [assignment:other local logging method]_] of audit records in the event that an interruption of communication with the remote syslog server occurs.
+*FAU_STG_EXT.1.3* The TSF shall maintain a [_selection: log file, database, buffer, [assignment:other local logging method]_] of audit records in the event that an interruption of communication with the remote audit server occurs.
 
 *FAU_STG_EXT.1.4* The TSF shall be able to store [_selection: persistent, non-persistent_] audit records locally with a minimum storage size of [_assignment: number of records, file/buffer size(s)_].
 

--- a/NDcPP_v3_0.adoc
+++ b/NDcPP_v3_0.adoc
@@ -525,7 +525,7 @@ SFR Rationale:
 
 * Requirements for basic auditing capabilities are specified in FAU_GEN.1 and FAU_GEN.2, with timestamps provided according to FPT_STM_EXT.1 and if applicable, protection of NTP channels in FCS_NTP_EXT.1.
 * Requirements for protecting audit records stored on the TOE are specified in FAU_STG.1.
-* Requirements for secure storage and transmission of local audit records to an external IT entity via a secure channel are specified in FAU_STG_EXT.1/Remote and FAU_STG_EXT.1.
+* Requirements for secure storage and transmission of local audit records to an external IT entity via a secure channel are specified in FAU_STG_EXT.1 and FAU_STG_EXT.1.
 * Optional additional requirements for dealing with potential loss of locally stored audit records are specified in FAU_STG_EXT.2, and FAU_STG_EXT.3.
 * If (optionally) configuration of the audit functionality is provided by the TOE then this is specified in FMT_SMF.1 and confining this functionality to Security Administrators is required by FMT_MOF.1/Functions.
 


### PR DESCRIPTION
Completed changes for issue #104.

1. Renaming FAU_STG_EXT.1 to FAU_STG_EXT.1/Remote.  See detailed list of changes described below regarding bullet 3.
2. As described on Jan 23, though at time of editing the app note number changed to app note 123.
3. As described above on Jan 23.
4. ...
   * 4.A: As described above on Jan 23.
   * 4.B: As described above on Jan 23, with the follow up noted on Mar 12.
5. As described above on Jan 23, except at the time of editing Test 1 had been deleted, so Test 3 became Test 2 and Test 4 became Test 3.

* Bullet 1: No changes to docs.
* Bullet 2: No changes to docs.

* Bullet 3, summary of changes:

**In the PP…**

Changed FAU_STG_EXT.1.3 to FAU_STG_EXT.1.3/LocSpace in:
•	Section A.2.1.2, FAU_STG_EXT.2.1.
•	Section C.1.2.3, FAU_STG_EXT.2.1.

Changed FAU_STG_EXT.1 to */Remote in:
•	Table in section 3.4, “Allocation of Requirements in Distributed TOEs”
•	T.UNDETECTED_ACTIVITY
•	Table in FAU_GEN.1.
•	The SFR itself (four instances).
•	FAU_STG_EXT.4.1 application note.
•	FAU_STG_EXT.5.1 application note.
•	FMT_MOF.1.1/Functions application note (first bullet).
•	Section C.1.2.1 (not C.1.2), four instances.
•	Section C.1.2.2 (second bullet under dependencies).
•	Section C.1.2.3 (second bullet under dependencies).
•	Section C.1.2.4 (second bullet under dependencies).
•	Section E.1 table of SFR Dependency Analysis (three instances).
•	Section E.1 table of SFR Dependencies Rationale for Mandatory SFRs (two instances).

**In the SD…**

Changed FAU_STG_EXT.1.2 to FAU_STG_EXT.1.2/LocSpace in:
•	Section 2.1.4.3, FAU_STG_EXT.1/LocSpace Test 3 (was test 4).
•	Section 3.1.3, opening sentence.
•	Section 4.5.3.3 Test 1, under “If 'handling of audit data'…”.
•	Section 4.5.3.3 Test 2, under “If 'handling of audit data'…”.

Changed FAU_STG_EXT.1.3 to FAU_STG_EXT.1.3/LocSpace in:
•	Section 2.1.4.3, FAU_STG_EXT.1/LocSpace Test 2 (was test 3).
•	Section 3.1.2, opening sentence. 
•	Section 3.1.2.3 (first test for FAU_STG_EXT.2).
•	Section 3.1.3, opening sentence.
•	Section 4.5.3.3 Test 1, under “If 'handling of audit data'…”.
•	Section 4.5.3.3 Test 2, under “If 'handling of audit data'…”.

Renamed FAU_STG_EXT.1 to */Remote in:
•	Section 2.1.1 (one instance).
•	Section 2.1.3 (heading).