### PR TITLE
MiNT Edwards-Curve removed based on NIAP comments

### DIFF
--- a/ND_Supporting_Document_3_0.adoc
+++ b/ND_Supporting_Document_3_0.adoc
@@ -569,22 +569,6 @@ CT[i] = AES-ECB-Encrypt(Key, PT) PT = CT[i]
 [arabic, start=126]
 . For each supported NIST curve (i.e., P-256, P-384 and P-521) and SHA function pair, the evaluator shall generate a set of 10 1024-bit message, public key and signature tuples and modify one of the values (message, public key or signature) in five of the 10 tuples. The evaluator shall obtain in response a set of 10 PASS/FAIL values.
 
-*EDDSA Algorithm Tests*
-
-*_EDDSA FIPS 186-5 Signature Generation Test_*
-
-[arabic, start=127]
-. The evaluator shall use the Ed25519 curve and the SHA-512 function pair to generate signatures for 10, 1024-bit long messages, and obtain for each message, a public key and the resulting signature values R and S. To determine correctness, the evaluator shall use the signature verification function of a known good implementation.
-
-. The evaluator shall use the Ed25519 curve and the SHA-512 function pair to generate signatures for 10, 1024-bit long messages. The first of these 10 messages will be unique and the subsequent 9 messages shall be derived from the first message by flipping individual bits in the original message. For each of these messages, obtain a public key and the resulting signature values R and S. The evaluator shall verify that the resulting signature values are distinct. Furthermore, to determine correctness, the evaluator shall use the signature verification function of a known good implementation.
-
-
-*_EDDSA FIPS 186-5 Signature Verification Test_*
-
-[arabic, start=129]
-. The evaluator shall use the Ed25519 curve and the SHA-512 function to generate a set of 10 1024-bit messages, public key and signature tuples and modify one of the values (message, public key or signature) in five of the 10 tuples. The evaluator shall obtain in response a set of 10 PASS/FAIL values.
-
-
 
 *RSA Signature Algorithm Tests*
 

--- a/NDcPP_v3_0.adoc
+++ b/NDcPP_v3_0.adoc
@@ -232,7 +232,7 @@ The PP-Modules that are allowed to specify this cPP as a base-PP are specified i
 
 The packages to which conformance can be claimed in conjunction with this cPP are:
 
-- Functional Package for SSH Version 1.0.
+- Functional Package for SSH Version 1.0 conformant
 
 All cryptographic selections in the above package must comply with FCS_COP and FCS_CKM requirements of this cPP.
 
@@ -1031,14 +1031,13 @@ _For the first selection of FCS_COP.1.1/DataEncryption, the ST author chooses th
 
 * _RSA Digital Signature Algorithm,_
 * _Elliptic Curve Digital Signature Algorithm_
-* _Edwards-Curve Digital Signature Algorithm_ 
+
 ]
 
 and cryptographic key sizes [selection:
 
 * _For RSA: modulus 2048 bits or greater,_
 * _For ECDSA: 256 bits or greater_
-* _For EdDSA: Ed25519_
 
 ]
 
@@ -1046,7 +1045,6 @@ that meet the following: [selection:
 
 * _For RSA schemes: FIPS PUB 186-4, “Digital Signature Standard (DSS)”, Section 5.5, using PKCS #1 v2.1 Signature Schemes RSASSA-PSS and/or RSASSA-PKCS1v1_5; ISO/IEC 9796-2, Digital signature scheme 2 or Digital Signature scheme 3,_
 * _For ECDSA schemes: FIPS PUB 186-4, “Digital Signature Standard (DSS)”, Section 6 and Appendix D, Implementing “NIST curves”_ [selection: _P-256, P-384, P-521_]; _ISO/IEC 14888-3, Section 6.4,_ 
-* _For EdDSA schemes: FIPS PUB 186-5, “Digital Signature Standard (DSS)”, Section 7_
 
 ].
 


### PR DESCRIPTION
Comment 1, cPP section 2.2 - added “conformant” after “Functional Package for SSH Version 1.0” per NIAP's request
Comment 6, cPP FCS_COP.1.1/SigGen - removed EDDSA selections per NIAP's request
Comment 43, SD FCS_COP.1.1/SigGen - removed all EDDSA references per NIAP's request