### PR TITLE
Ky20230925 app note clarifications

### DIFF
--- a/ND_Supporting_Document_3_0.adoc
+++ b/ND_Supporting_Document_3_0.adoc
@@ -812,7 +812,7 @@ CT[i] = AES-ECB-Encrypt(Key, PT) PT = CT[i]
 ===== TSS
 
 [arabic, start=182]
-. The evaluator shall examine the TSS to ensure that it details the self-tests that are run by the TSF; this description should include an outline of what the tests are actually doing (e.g., rather than saying "memory is tested", a description similar to "memory is tested by writing a value to each memory location and reading it back to ensure it is identical to what was written" shall be used). The evaluator shall ensure that the TSS makes an argument that the tests are sufficient to demonstrate that the TSF is operating correctly.
+. The evaluator shall examine the TSS to ensure that it details the self-tests that are run by the TSF; this description should include an outline of what the tests are actually doing (e.g., rather than saying "memory is tested", a description similar to "memory is tested by writing a value to each memory location and reading it back to ensure it is identical to what was written" shall be used). The evaluator shall ensure that the TSS makes an argument that the tests are sufficient to demonstrate that the TSF is operating correctly. If more than one failure response is listed in FPT_TST_EXT.1.2, the evaluator shall examine the TSS to ensure it clarifies which response is associated with which type of failure.
 . For distributed TOEs the evaluator shall examine the TSS to ensure that it details which TOE component performs which self-tests and when these self-tests are run. The evaluator shall also examine the TSS to ensure it describes how the TOE reacts if one or more TOE components fail self-testing (e.g. halting and displaying an error message; failover behaviour).
 
 ===== Guidance Documentation

--- a/ND_Supporting_Document_3_0.adoc
+++ b/ND_Supporting_Document_3_0.adoc
@@ -1304,16 +1304,6 @@ Some TOEs may set up the registration channel before the enablement step is carr
 [arabic, start=279]
 . The evaluator shall ensure that the TSS description required per FIA_X509_EXT.2.1 includes the use of client-side certificates for DTLS mutual authentication.
 
-*FCS_DTLSC_EXT.2.2*
-
-[arabic, start=280]
-. The evaluator shall verify that the TSS describes the actions that take place if a message received from the DTLS Server fails the MAC integrity check.
-
-*FCS_DTLSC_EXT.2.3*
-
-[arabic, start=281]
-. The evaluator shall verify that TSS describes how replay is detected and silently discarded for DTLS records that have previously been received and too old to fit in the sliding window.
-
 ===== Guidance Documentation
 
 *FCS_DTLSC_EXT.2.1*
@@ -1333,17 +1323,6 @@ Some TOEs may set up the registration channel before the enablement step is carr
 . Test 1: The evaluator shall establish a connection to a peer server that is configured for mutual authentication (i.e. sends a server Certificate Request (type 13) message). The evaluator observes that the TOE DTLS client sends both client Certificate (type 11) and client Certificate Verify (type 15) messages during its negotiation of a DTLS channel and that Application Data is sent.
 +
 In addition, all other testing in FCS_DTLSC_EXT.1 and FIA_X509_EXT.* must be performed as per the requirements.
-
-
-*FCS_DTLSC_EXT.2.2*
-
-[arabic, start=285]
-. Test 1: The evaluator shall establish a DTLS connection. The evaluator will then modify at least one byte in a record message and verify that the Client discards the record or terminates the DTLS session.
-
-*FCS_DTLSC_EXT.2.3*
-
-[arabic, start=286]
-. Test 1: The evaluator shall set up a DTLS connection with a DTLS Server. The evaluator shall then capture traffic sent from the DTLS Server to the TOE. The evaluator shall retransmit copies of this traffic to the TOE in order to impersonate the DTLS Server. The evaluator shall observe that the TSF does not take action in response to receiving these packets and that the audit log indicates that the replayed traffic was discarded.
 
 ==== FCS_DTLSS_EXT.2 Extended: DTLS Server support for mutual authentication
 
@@ -1618,6 +1597,16 @@ Note: Testing the validity of the client certificate is performed as part of X.5
 [arabic, start=347]
 . The evaluator shall verify in the TSS that, for DTLS 1.3, the TOE shall not permit out-of-band provisioning of pre-shared keys (PSKs) in the evaluated configuration.
 
+*FCS_DTLSC_EXT.1.10*
+
+[arabic, start=348]
+. The evaluator shall verify that the TSS describes the actions that take place if a message received from the DTLS Server fails the MAC integrity check.
+
+*FCS_DTLSC_EXT.1.11*
+
+[arabic, start=349]
+. The evaluator shall verify that TSS describes how replay is detected and silently discarded for DTLS records that have previously been received and too old to fit in the sliding window.
+
 ===== Guidance Documentation
 
 *FCS_DTLSC_EXT.1.1*
@@ -1786,6 +1775,16 @@ Remark: Some systems might require the presence of the SAN extension. In this ca
 .. Test 3 [conditional]: If "support DTLS 1.2 secure renegotiation..." is selected, the evaluator shall perform a DTLS 1.2 handshake and verify that ServerHello messages received during secure renegotiation contain the “renegotiation_info” extension. The evaluator shall modify either the “client_verify_data” or “server_verify_data” value and verify that the TOE DTLS client terminates the connection.
 .. Test 4 [conditional]: If "reject...renegotiation attemps" is selected, then for each selected DTLS version, the evaluator shall initiate a DTLS session between the so-configured TSF and a test server that is configured to perform a compliant handshake, followed by a hello reset request. The evaluator shall confirm that the TSF completes the initial handshake successfully but terminates the DTLS session after receiving the hello reset request. 
 Note: It is preferred that the TSF sends a fatal error alert message (e.g., unexpected message) in response to this, but it is acceptable that the TSF terminates the connection silently (i.e., without sending a fatal error alert).
+
+*FCS_DTLSC_EXT.1.10*
+
+[arabic, start=265]
+. Test 1: The evaluator shall establish a DTLS connection. The evaluator will then modify at least one byte in a record message and verify that the Client discards the record or terminates the DTLS session.
+
+*FCS_DTLSC_EXT.1.11*
+
+[arabic, start=266]
+. Test 1: The evaluator shall set up a DTLS connection with a DTLS Server. The evaluator shall then capture traffic sent from the DTLS Server to the TOE. The evaluator shall retransmit copies of this traffic to the TOE in order to impersonate the DTLS Server. The evaluator shall observe that the TSF does not take action in response to receiving these packets and that the audit log indicates that the replayed traffic was discarded.
 
 ==== FCS_DTLSS_EXT.1 Extended: DTLS Server Protocol
 

--- a/ND_Supporting_Document_3_0.adoc
+++ b/ND_Supporting_Document_3_0.adoc
@@ -1345,34 +1345,6 @@ In addition, all other testing in FCS_DTLSC_EXT.1 and FIA_X509_EXT.* must be per
 [arabic, start=286]
 . Test 1: The evaluator shall set up a DTLS connection with a DTLS Server. The evaluator shall then capture traffic sent from the DTLS Server to the TOE. The evaluator shall retransmit copies of this traffic to the TOE in order to impersonate the DTLS Server. The evaluator shall observe that the TSF does not take action in response to receiving these packets and that the audit log indicates that the replayed traffic was discarded.
 
-==== FCS_DTLSC_EXT.3 Extended: DTLS Client support for secure renegotiation (DTLSv1.2 only)
-
-===== TSS
-
-*FCS_DTLSC_EXT.3.1*
-
-[arabic, start=287]
-. None.
-
-===== Guidance Documentation
-
-*FCS_DTLSC_EXT.3.1*
-
-[arabic, start=288]
-. None
-
-===== Tests
-
-*FCS_DTLSC_EXT.3.1*
-
-[arabic, start=289]
-. The evaluator shall perform the following tests:
-
-[loweralpha, start=1]
-.. Test 1: The evaluator shall use a network packet analyzer/sniffer to capture the traffic between the two DTLS endpoints. The evaluator shall verify that either the “renegotiation_info” field or the SCSV cipher suite is included in the ClientHello message during the initial handshake.
-.. Test 2: The evaluator shall verify the TOE DTLS Client’s handling of ServerHello messages received during the initial handshake that include the “renegotiation_info” extension. The evaluator shall modify the length portion of this field in the ServerHello message to be non-zero and verify that the TOE DTLS client sends a failure and terminates the connection. The evaluator shall verify that a properly formatted field results in a successful DTLS connection.
-.. Test 3: The evaluator shall verify that ServerHello messages received during secure renegotiation contain the “renegotiation_info” extension. The evaluator shall modify either the “client_verify_data” or “server_verify_data” value and verify that the TOE DTLS client terminates the connection.
-
 ==== FCS_DTLSS_EXT.2 Extended: DTLS Server support for mutual authentication
 
 ===== TSS
@@ -1457,34 +1429,6 @@ Note: Testing the validity of the client certificate is performed as part of X.5
 ... The evaluator shall examine the Certificate Request message and verify it contains the signature_algorithms_cert extension and the SignatureSchemes match the SignatureSchemes specified in the requirement.
 ... The evaluator shall establish a DTLS connection and perform client authentication using a certificate chain using each of the SignatureSchemes specified by the requirement. The evaluator shall ensure the signatures used in the certificate chain are consistent with the SignatureScheme being tested.
 
-==== FCS_DTLSS_EXT.3 Extended: DTLS Server support for secure renegotiation (DTLSv1.2 only)
-
-===== TSS
-
-*FCS_DTLSS_EXT.3.1*
-
-[arabic, start=302]
-. None.
-
-===== Guidance Documentation
-
-*FCS_DTLSS_EXT.3.1*
-
-[arabic, start=303]
-. None
-
-===== Tests
-
-[arabic, start=304]
-. The evaluator shall perform the following tests. The following tests require connection with a client that supports secure renegotiation and the ”renegotiation_info” extension.
-
-*FCS_DTLSS_EXT.3.1*
-
-[arabic, start=305]
-. Test 1: The evaluator shall use a network packet analyzer/sniffer to capture the traffic between the two DTLS endpoints. The evaluator shall verify that the “renegotiation_info” field is included in the ServerHello message.
-. Test 2: The evaluator shall modify the length portion of the field in the ClientHello message in the initial handshake to be non-zero and verify that the TOE DTLS server sends a failure and terminates the connection. The evaluator shall verify that a properly formatted field results in a successful DTLS connection.
-. Test 3: The evaluator shall modify the "client_verify_data" or "server_verify_data" value in the ClientHello message received during secure renegotiation and verify that the TOE DTLS server terminates the connection.
-
 ==== FCS_TLSC_EXT.2 Extended: TLS Client support for mutual authentication
 
 ===== TSS
@@ -1513,35 +1457,6 @@ Note: Testing the validity of the client certificate is performed as part of X.5
 . Test 1: The evaluator shall establish a connection to a peer server that is configured for mutual authentication (i.e. sends a server Certificate Request (type 13) message). The evaluator observes that the TOE TLS client sends both client Certificate (type 11) and client Certificate Verify (type 15) messages during its negotiation of a TLS channel and that Application Data is sent.
 +
 In addition, all other testing in FCS_TLSC_EXT.1 and FIA_X509_EXT.* must be performed as per the requirements.
-
-
-==== FCS_TLSC_EXT.3 Extended: TLS Client support for secure renegotiation (TLSv1.2 only)
-
-===== TSS
-
-*FCS_TLSC_EXT.3.1*
-
-[arabic, start=312]
-. None.
-
-===== Guidance Documentation
-
-*FCS_TLSC_EXT.3.1*
-
-[arabic, start=313]
-. None
-
-===== Tests
-
-*FCS_TLSC_EXT.3.1*
-
-[arabic, start=314]
-. The evaluator shall perform the following tests:
-
-[loweralpha, start=1]
-.. Test 1: The evaluator shall use a network packet analyzer/sniffer to capture the traffic between the two TLS endpoints. The evaluator shall verify that either the “renegotiation_info” field or the SCSV cipher suite is included in the ClientHello message during the initial handshake.
-.. Test 2: The evaluator shall verify the TOE TLS Client’s handling of ServerHello messages received during the initial handshake that include the “renegotiation_info” extension. The evaluator shall modify the length portion of this field in the ServerHello message to be non-zero and verify that the TOE TLS client sends a failure and terminates the connection. The evaluator shall verify that a properly formatted field results in a successful TLS connection.
-.. Test 3: The evaluator shall verify that ServerHello messages received during secure renegotiation contain the “renegotiation_info” extension. The evaluator shall modify either the “client_verify_data” or “server_verify_data” value and verify that the TOE TLS client terminates the connection.
 
 ==== FCS_TLSS_EXT.2 Extended: TLS Server support for mutual authentication
 
@@ -1627,36 +1542,6 @@ Note: Testing the validity of the client certificate is performed as part of X.5
 [lowerroman]
 ... The evaluator shall examine the Certificate Request message and verify it contains the signature_algorithms_cert extension and the SignatureSchemes match the SignatureSchemes specified in the requirement.
 ... The evaluator shall establish a TLS connection and perform client authentication using a certificate chain using each of the SignatureSchemes specified by the requirement. The evaluator shall ensure the signatures used in the certificate chain are consistent with the SignatureScheme being tested.
-
-==== FCS_TLSS_EXT.3 Extended: TLS Server support for secure renegotiation (TLSv1.2 only)
-
-===== TSS
-
-*FCS_TLSS_EXT.3.1*
-
-[arabic, start=327]
-. None.
-
-===== Guidance Documentation
-
-*FCS_TLSS_EXT.3.1*
-
-[arabic, start=328]
-. None
-
-===== Tests
-
-[arabic, start=329]
-. The evaluator shall perform the following tests. The following tests require connection with a client that supports secure renegotiation and the ”renegotiation_info” extension.
-
-*FCS_TLSS_EXT.3.1*
-
-[arabic, start=330]
-. The evaluator shall perform the following tests:
-[loweralpha, start=1]
-.. Test 1: The evaluator shall use a network packet analyzer/sniffer to capture the traffic between the two TLS endpoints. The evaluator shall verify that the “renegotiation_info” field is included in the ServerHello message.
-.. Test 2: The evaluator shall modify the length portion of the field in the ClientHello message in the initial handshake to be non-zero and verify that the TOE TLS server sends a failure and terminates the connection. The evaluator shall verify that a properly formatted field results in a successful TLS connection.
-.. Test 3: The evaluator shall modify the "client_verify_data" or "server_verify_data" value in the ClientHello message received during secure renegotiation and verify that the TOE TLS server terminates the connection.
 
 == Evaluation Activities for Selection-Based Requirements
 
@@ -1890,6 +1775,18 @@ Remark: Some systems might require the presence of the SAN extension. In this ca
 [arabic, start=364]
 . The evaluator shall establish a DTLS connection with a server and observe that the early data extension and the post-handshake client authentication extension according to RFC 9147, section 5.8.4 are not advertised in the Client Hello Message. This test shall be executed for all DTLS versions supported by the TOE.
 
+*FCS_DTLSC_EXT.1.9*
+
+[arabic, start=365]
+. The evaluator shall perform the following tests:
+
+[loweralpha, start=1]
+.. Test 1 [conditional]: If "support DTLS 1.2 secure renegotiation..." is selected, the evaluator shall use a network packet analyzer/sniffer to capture a DTLS 1.2 handshake between the two DTLS endpoints. The evaluator shall verify that either the “renegotiation_info” field or the SCSV cipher suite is included in the ClientHello message during the initial handshake.
+.. Test 2 [conditional]: If "support DTLS 1.2 secure renegotiation..." is selected, the evaluator shall perform a DTLS 1.2 handshake and verify the TOE DTLS Client’s handling of ServerHello messages received during the initial handshake that include the “renegotiation_info” extension. The evaluator shall modify the length portion of this field in the ServerHello message to be non-zero and verify that the TOE DTLS client sends a failure and terminates the connection. The evaluator shall verify that a properly formatted field results in a successful DTLS connection.
+.. Test 3 [conditional]: If "support DTLS 1.2 secure renegotiation..." is selected, the evaluator shall perform a DTLS 1.2 handshake and verify that ServerHello messages received during secure renegotiation contain the “renegotiation_info” extension. The evaluator shall modify either the “client_verify_data” or “server_verify_data” value and verify that the TOE DTLS client terminates the connection.
+.. Test 4 [conditional]: If "reject...renegotiation attemps" is selected, then for each selected DTLS version, the evaluator shall initiate a DTLS session between the so-configured TSF and a test server that is configured to perform a compliant handshake, followed by a hello reset request. The evaluator shall confirm that the TSF completes the initial handshake successfully but terminates the DTLS session after receiving the hello reset request. 
+Note: It is preferred that the TSF sends a fatal error alert message (e.g., unexpected message) in response to this, but it is acceptable that the TSF terminates the connection silently (i.e., without sending a fatal error alert).
+
 ==== FCS_DTLSS_EXT.1 Extended: DTLS Server Protocol
 
 ===== TSS
@@ -2087,6 +1984,18 @@ Remark: If multiple contexts are supported for session resumption, for each of t
 
 [arabic, start=392]
 . According to RFC8446 section 4.2.10, a PSK is required to use the early data extension. As NDcPP only allows the use of PSK in conjunction with session resumption, a NDcPP conformant TOE which acts as DTLS Server cannot use the early data extension if session resumption is not supported. For TOEs that do not support session resumption, execution of test FCS_DTLSS_EXT.1.7 Test 1 is regarded as sufficient that the TOE does not support the early data extension. For TOEs that support session resumption, FCS_DTLSS_EXT.1.7 Test 2(i), 3(i) or 4(i) (depending on the supported DTLS versions and the way session resumption is implemented) ensure that the TOE does not support the early data extension.
+
+*FCS_DTLSS_EXT.1.11*
+
+[arabic, start=393]
+. The evaluator shall perform the following tests:
+
+[loweralpha, start=1]
+.. Test 1 [conditional]: If "support secure renegotiation..." is selected, the evaluator shall use a network packet analyzer/sniffer to capture a DTLS 1.2 handshake between the two DTLS endpoints. The evaluator shall verify that the “renegotiation_info” extension is included in the ServerHello message.
+.. Test 2 [conditional]: If "support secure renegotiation..." is selected, the evaluator shall perform a DTLS 1.2 handshake and modify the length portion of the field in the ClientHello message in the initial handshake to be non-zero. The evaluator shall verify that the TOE DTLS server sends a failure and terminates the connection. The evaluator shall verify that a properly formatted field results in a successful DTLS connection.
+.. Test 3 [conditional]: If "support secure renegotiation..." is selected, the evaluator shall perform a DTLS 1.2 handshake and modify the "client_verify_data" or "server_verify_data" value in the ClientHello message received during secure renegotiation. The evaluator shall verify that the TOE DTLS server terminates the connection.
+.. Test 4 [conditional]: If "reject...renegotiation attemps" is selected, then for each selected DTLS version, the evaluator shall follow the operational guidance as necessary to configure the TSF to negotiate the version and reject renegotiation. The evaluator shall initiate a valid initial session for the specified version, send a valid ClientHello on the non-renegotiable DTLS channel, and observe that the TSF terminates the session.
+Note: It is preferred that the TSF sends a fatal error alert message (e.g., unexpected message) in response to this, but it is acceptable that the TSF terminates the connection silently (i.e., without sending a fatal error alert).
 
 ==== FCS_HTTPS_EXT.1 HTTPS Protocol
 
@@ -2606,6 +2515,17 @@ Remark: Some systems might require the presence of the SAN extension. In this ca
 [arabic, start=478]
 . The evaluator shall establish a TLS connection with a server and observe that the early data extension and the post-handshake client authentication extension according to RFC8446 Section 4.2 are not advertised in the Client Hello Message. This test shall be executed for all TLS versions supported by the TOE.
 
+*FCS_TLSC_EXT.1.9*
+
+[arabic, start=479]
+. The evaluator shall perform the following tests:
+
+[loweralpha, start=1]
+.. Test 1 [conditional]: If "support TLS 1.2 secure renegotiation..." is selected, the evaluator shall use a network packet analyzer/sniffer to capture a TLS 1.2 handshake between the two TLS endpoints. The evaluator shall verify that either the “renegotiation_info” field or the SCSV cipher suite is included in the ClientHello message during the initial handshake.
+.. Test 2 [conditional]: If "support TLS 1.2 secure renegotiation..." is selected, the evaluator shall perform a TLS 1.2 handshake and verify the TOE TLS Client’s handling of ServerHello messages received during the initial handshake that include the “renegotiation_info” extension. The evaluator shall modify the length portion of this field in the ServerHello message to be non-zero and verify that the TOE TLS client sends a failure and terminates the connection. The evaluator shall verify that a properly formatted field results in a successful TLS connection.
+.. Test 3 [conditional]: If "support TLS 1.2 secure renegotiation..." is selected, the evaluator shall perform a TLS 1.2 handshake and verify that ServerHello messages received during secure renegotiation contain the “renegotiation_info” extension. The evaluator shall modify either the “client_verify_data” or “server_verify_data” value and verify that the TOE TLS client terminates the connection.
+.. Test 4 [conditional]: If "reject...renegotiation attemps" is selected, then for each selected TLS version, the evaluator shall initiate a TLS session between the so-configured TSF and a test server that is configured to perform a compliant handshake, followed by a hello reset request. The evaluator shall confirm that the TSF completes the initial handshake successfully but terminates the TLS session after receiving the hello reset request. 
+Note: It is preferred that the TSF sends a fatal error alert message (e.g., unexpected message) in response to this, but it is acceptable that the TSF terminates the connection silently (i.e., without sending a fatal error alert).
 
 ==== FCS_TLSS_EXT.1 Extended: TLS Server Protocol
 
@@ -2776,6 +2696,18 @@ Remark: If multiple contexts are supported for session resumption, for each of t
 
 [arabic, start=499]
 . According to RFC8446 section 4.2.10, a PSK is required to use the early data extension. As NDcPP only allows the use of PSK in conjunction with session resumption, a NDcPP conformant TOE which acts as TLS Server cannot use the early data extension if session resumption is not supported. For TOEs that do not support session resumption, execution of test FCS_TLSS_EXT.1.4 Test 1 is regarded as sufficient that the TOE does not support the early data extension. For TOEs that support session resumption, FCS_TLSS_EXT.1.4 Test 2(i), 3(i) or 4(i) (depending on the supported TLS versions and the way session resumption is implemented) ensure that the TOE does not support the early data extension.
+
+*FCS_TLSS_EXT.1.8*
+
+[arabic, start=500]
+. The evaluator shall perform the following tests:
+
+[loweralpha, start=1]
+.. Test 1 [conditional]: If "support secure renegotiation..." is selected, the evaluator shall use a network packet analyzer/sniffer to capture a TLS 1.2 handshake between the two TLS endpoints. The evaluator shall verify that the “renegotiation_info” extension is included in the ServerHello message.
+.. Test 2 [conditional]: If "support secure renegotiation..." is selected, the evaluator shall perform a TLS 1.2 handshake and modify the length portion of the field in the ClientHello message in the initial handshake to be non-zero. The evaluator shall verify that the TOE TLS server sends a failure and terminates the connection. The evaluator shall verify that a properly formatted field results in a successful TLS connection.
+.. Test 3 [conditional]: If "support secure renegotiation..." is selected, the evaluator shall perform a TLS 1.2 handshake and modify the "client_verify_data" or "server_verify_data" value in the ClientHello message received during secure renegotiation. The evaluator shall verify that the TOE TLS server terminates the connection.
+.. Test 4 [conditional]: If "reject...renegotiation attemps" is selected, then for each selected TLS version, the evaluator shall follow the operational guidance as necessary to configure the TSF to negotiate the version and reject renegotiation. The evaluator shall initiate a valid initial session for the specified version, send a valid ClientHello on the non-renegotiable TLS channel, and observe that the TSF terminates the session.
+Note: It is preferred that the TSF sends a fatal error alert message (e.g., unexpected message) in response to this, but it is acceptable that the TSF terminates the connection silently (i.e., without sending a fatal error alert).
 
 === Identification and Authentication (FIA)
 

--- a/NDcPP_v3_0.adoc
+++ b/NDcPP_v3_0.adoc
@@ -1837,23 +1837,6 @@ A TOE may act as the client, the server, or both in DTLS sessions. The requireme
 
 _The use of X.509v3 certificates for DTLS is addressed in FIA_X509_EXT.2.1. This requirement adds that the client must be capable of presenting a certificate to a DTLS server for DTLS mutual authentication._
 
-*FCS_DTLSC_EXT.2.2* The TSF shall [selection: _terminate the DTLS session, silently discard the record_] if a message received contains an invalid MAC.
-
-*_Application Note {counter:appnote_count}_*
-
-_The Message Authentication Code (MAC) is negotiated during the DTLS handshake phase and is used to protect the integrity of messages received from the sender during DTLS data exchange (see 'Handling Invalid Records' in RFC 9147 (DTLS 1.3), section 4.5.2 and RFC 6347 (DTLS 1.2), section 4.1.2.7). If MAC verification fails, the session must be terminated, or the record must be silently discarded._
-
-*FCS_DTLSC_EXT.2.3* The TSF shall detect and silently discard replayed messages for:
-
-* DTLS records previously received.
-* DTLS records too old to fit in the sliding window.
-
-*_Application Note {counter:appnote_count}_*
-
-_Replay Detection is described in section 4.5.1 of DTLS 1.3 (RFC 9147) and 4.1.2.6 of DTLS 1.2 (RFC 6347). For each received record, the receiver verifies the record contains a sequence number that is within the sliding receive window and does not duplicate the sequence number of any other record received during the session._
-
-_"Silently Discard" means the TOE discards the packet without responding._
-
 *FCS_DTLSS_EXT.2 DTLS Server Support for Mutual Authentication*
 
 *FCS_DTLSS_EXT.2.1* The TSF shall support DTLS communication with mutual authentication of DTLS clients using X.509v3 certificates and shall [selection:
@@ -2309,6 +2292,23 @@ _RFC 5746 defines an extension to DTLS that binds renegotiation handshakes to th
 _The “renegotiation_info” extension must be presented by the server to signal support for secure renegotiation and must be presented by the client to perform secure renegotiation._
 
 _When signaling support for secure renegotiation, the client may present either the “renegotiation_info” extension or the signaling cipher suite value TLS_EMPTY_RENEGOTIATION_INFO_SCSV in the initial ClientHello message. (A signaling cipher suite value (SCSV) is presented as a cipher suite, but its only purpose is to provide other information and not to advertise support for a cipher suite.) The TLS_EMPTY_RENEGOTIATION_INFO_SCSV signaling cipher suite value exists as an alternative to presenting the “renegotation_info” extension so that DTLS server implementations that immediately terminate the connection when they encounter any extension they do not understand can still proceed with a connection. The client may still choose to reject the connection later, if it insists upon renegotiation support and the server does not support it._
+
+*FCS_DTLSC_EXT.1.10* The TSF shall [selection: _terminate the DTLS session, silently discard the record_] if a message received contains an invalid MAC.
+
+*_Application Note {counter:appnote_count}_*
+
+_The Message Authentication Code (MAC) is negotiated during the DTLS handshake phase and is used to protect the integrity of messages received from the sender during DTLS data exchange (see 'Handling Invalid Records' in RFC 9147 (DTLS 1.3), section 4.5.2 and RFC 6347 (DTLS 1.2), section 4.1.2.7). If MAC verification fails, the session must be terminated, or the record must be silently discarded._
+
+*FCS_DTLSC_EXT.1.11* The TSF shall detect and silently discard replayed messages for:
+
+* DTLS records previously received.
+* DTLS records too old to fit in the sliding window.
+
+*_Application Note {counter:appnote_count}_*
+
+_Replay Detection is described in section 4.5.1 of DTLS 1.3 (RFC 9147) and 4.1.2.6 of DTLS 1.2 (RFC 6347). For each received record, the receiver verifies the record contains a sequence number that is within the sliding receive window and does not duplicate the sequence number of any other record received during the session._
+
+_"Silently Discard" means the TOE discards the packet without responding._
 
 *FCS_DTLSS_EXT.1 DTLS Server Protocol*
 
@@ -3492,6 +3492,13 @@ _]._
 
 *FCS_DTLSC_EXT.1.9* The TSF shall [selection: _support DTLS 1.2 secure renegotiation through use of the “renegotiation_info” TLS extension in accordance with RFC 5746, reject [selection: DTLS 1.2, DTLS 1.3] renegotiation attempts_].
 
+*FCS_DTLSC_EXT.1.10* The TSF shall [selection: _terminate the DTLS session, silently discard the record_] if a message received contains an invalid MAC.
+
+*FCS_DTLSC_EXT.1.11* The TSF shall detect and silently discard replayed messages for:
+
+* DTLS records previously received;
+* DTLS records too old to fit in the sliding window.
+
 *FCS_DTLSC_EXT.2 DTLS Client Support for Mutual Authentication*
 
 Hierarchical to: No other components
@@ -3511,13 +3518,6 @@ Dependencies:
 * FIA_X509_EXT.3 X.509 Certificate Request
 
 *FCS_DTLSC_EXT.2.1* The TSF shall support mutual authentication using X.509v3 certificates.
-
-*FCS_DTLSC_EXT.2.2* The TSF shall [selection: _terminate the DTLS session, silently discard the record_] if a message received contains an invalid MAC.
-
-*FCS_DTLSC_EXT.2.3* The TSF shall detect and silently discard replayed messages for:
-
-* DTLS records previously received;
-* DTLS records too old to fit in the sliding window.
 
 =====  FCS_DTLSS_EXT DTLS Server Protocol
 

--- a/NDcPP_v3_0.adoc
+++ b/NDcPP_v3_0.adoc
@@ -1318,7 +1318,13 @@ In order to detect some number of failures of underlying security mechanisms use
 
 *FPT_TST_EXT.1 TSF Testing*
 
-*FPT_TST_EXT.1.1* The TSF shall run a suite of the following self-tests [selection: _during initial start-up (on power on), periodically during normal operation, at the request of the authorised user, at the conditions [assignment: conditions under which self-tests should occur]]_ to demonstrate the correct operation of the TSF: [_assignment: list of self-tests run by the TSF_].
+*FPT_TST_EXT.1.1* The TSF shall run a suite of the following self-tests [selection:
+
+ * _During initial start-up (on power on) to verify the integrity of the TOE firmware and software;_
+ * _During start-up (prior to providing any cryptographic services) and [selection: at no other time, on-demand, continuously, [assignment: conditions under which self-tests should occur]] to verify correct operation of cryptographic implementation necessary to fulfil the TSF;_
+* [selection: _no other, start-up, on-demand, continuous, at the conditions [assignment: conditions under which self-tests should occur]] self-tests [assignment: describe self-test objective]._
+
+to demonstrate the correct operation of the TSF: [assignment: _list of self-tests run by the TSF_] and if failure detected [assignment: _describe resulting error state_].
 
 *_Application Note {counter:appnote_count}_*
 
@@ -1327,6 +1333,8 @@ _It is expected that self-tests are carried out during initial start-up of the T
 _Non-distributed TOEs may internally consist of several components that contribute to enforcing SFRs. Self-testing shall cover all components that contribute to enforcing SFRs and verification of integrity shall cover all software that contributes to enforcing SFRs on all components._
 
 _For distributed TOEs all TOE components have to perform self-tests. This does not necessarily mean that each TOE component has to carry out the same self-tests: the ST describes the applicability of the selection (i.e. when self-tests are run) and the final assignment (i.e. which self-tests are carried out) to each TOE component._
+
+*FPT_TST_EXT.1.2* The TSF shall respond to [selection: _all failures, [assignment: list of failures detected by self-tests_]] by [selection: _entering a maintenance mode, rebooting, [assignment: other methods to enter a secure state_]].
 
 ==== Trusted Update (FPT_TUD_EXT)
 
@@ -4480,7 +4488,15 @@ Hierarchical to: No other components.
 
 Dependencies: No other components.
 
-*FPT_TST_EXT.1.1* The TSF shall run a suite of the following self-tests [selection: _during initial start-up (on power on), periodically during normal operation, at the request of the authorised user, at the conditions [assignment: conditions under which self-tests should occur]_] to demonstrate the correct operation of the TSF: _[assignment: list of self-tests run by the TSF_].
+*FPT_TST_EXT.1.1* The TSF shall run a suite of the following self-tests [selection:
+
+ * _During initial start-up (on power on) to verify the integrity of the TOE firmware and software;_
+ * _During start-up (prior to providing any cryptographic services) and [selection: at no other time, on-demand, continuously, [assignment: conditions under which self-tests should occur]] to verify correct operation of cryptographic implementation necessary to fulfil the TSF;_
+* [selection: _no other, start-up, on-demand, continuous, at the conditions [assignment: conditions under which self-tests should occur]] self-tests [assignment: describe self-test objective]._
+
+to demonstrate the correct operation of the TSF: [assignment: _list of self-tests run by the TSF_] and if failure detected [assignment: _describe resulting error state_].
+
+*FPT_TST_EXT.1.2* The TSF shall respond to [selection: _all failures, [assignment: list of failures detected by self-tests_]] by [selection: _entering a maintenance mode, rebooting, [assignment: other methods to enter a secure state_]].
 
 ==== Trusted Update (FPT_TUD_EXT)
 

--- a/NDcPP_v3_0.adoc
+++ b/NDcPP_v3_0.adoc
@@ -1625,10 +1625,6 @@ a|
 |FCS_DTLSS_EXT.2 |Failure to authenticate the client |Reason for failure
 |FCS_TLSC_EXT.2 |None |None
 |FCS_TLSS_EXT.2 |Failure to authenticate the client |Reason for failure
-|FCS_DTLSC_EXT.3 |None |None
-|FCS_DTLSS_EXT.3 |None |None
-|FCS_TLSC_EXT.3 |None |None
-|FCS_TLSS_EXT.3 |None |None
 |===
 
 [#_Ref397655544]#Table 4: TOE Optional SFRs and Auditable Events#
@@ -1827,15 +1823,11 @@ _Specific requirements for Preparative Procedures relating to FCO_CPC_EXT.1 are 
 
 =====  FCS_DTLSC_EXT & FCS_DTLSS_EXT DTLS Protocol
 
-Datagram TLS (DTLS) is not a required component of the NDcPP. If a TOE implements DTLS, a corresponding selection in FTP_ITC.1, FTP_TRP.1/Admin, or FPT_ITT.1 should be made to define what the DTLS protocol is implemented to protect. If a corresponding option to support DTLS has been selected in at least one of the SFRs named above, the corresponding selection-based DTLS-related SFRs should be added to the ST from chap. B.3.1.1 (i.e. FCS_DTLSC_EXT.1 and/or FCS_DTLSS_EXT.1). The SFRs therein cover only the minimum DTLS-related requirements without support for mutual authentication. The support for mutual authentication is optional when using DTLS. If a TOE implements DTLS with mutual authentication the corresponding optional SFRs should be added to the ST from chap. A.7.1.1 (i.e. FCS_DTLSC_EXT.2 and/or FCS_DTLSS_EXT.2) in addition to the corresponding SFRs from chap.B.3.1.1.
+Datagram TLS (DTLS) is not a required component of the NDcPP. If a TOE implements DTLS, a corresponding selection in FTP_ITC.1, FTP_TRP.1/Admin, or FPT_ITT.1 should be made to define what the DTLS protocol is implemented to protect. If a corresponding option to support DTLS has been selected in at least one of the SFRs named above, the corresponding selection-based DTLS-related SFRs should be added to the ST from chap. B.3.1.1 (i.e. FCS_DTLSC_EXT.1 and/or FCS_DTLSS_EXT.1). The SFRs therein cover only the minimum DTLS-related requirements without support for mutual authentication. 
+
+The support for mutual authentication is optional when using DTLS. If a TOE implements DTLS with mutual authentication the corresponding optional SFRs should be added to the ST from chap. A.7.1.1 (i.e. FCS_DTLSC_EXT.2 and/or FCS_DTLSS_EXT.2) in addition to the corresponding SFRs from chap.B.3.1.1.
 
 A TOE may act as the client, the server, or both in DTLS sessions. The requirement has been separated into DTLS Client (FCS_DTLSC_EXT) and DTLS Server (FCS_DTLSS_EXT) requirements to allow for these differences.
-
-If the TOE acts as the client during the claimed DTLS sessions, the ST author should claim the corresponding FCS_DTLSC_EXT requirements.
-
-To ensure audit requirements are properly met, a DTLS receiver may need to monitor the DTLS connection state at the application layer. When no data is received from a DTLS connection for a long time (where the application decides what "long" means), the receiver should send a close_notify alert message and close the connection.
-
-If the TOE acts as the server during the claimed DTLS sessions, the ST author should claim the corresponding FCS_DTLSS_EXT requirements. In this case the TOE needs to claim at least the FCS_DTLSS_EXT.1 requirements in chap. B.3.1.1 (no support for mutual authentication). If the TOE acts as DTLS server and in addition also supports mutual authentication, the FCS_DTLSS_EXT.2 requirements in chap. A.7.1.1 also need to be claimed in addition. If the TOE acts as both a client and server during the claimed TLS sessions, the ST author should claim the corresponding FCS_TLSC_EXT and FCS_TLSS_EXT requirements.
 
 *FCS_DTLSC_EXT.2 DTLS Client Support for Mutual Authentication*
 
@@ -1861,20 +1853,6 @@ _The Message Authentication Code (MAC) is negotiated during the DTLS handshake p
 _Replay Detection is described in section 4.5.1 of DTLS 1.3 (RFC 9147) and 4.1.2.6 of DTLS 1.2 (RFC 6347). For each received record, the receiver verifies the record contains a sequence number that is within the sliding receive window and does not duplicate the sequence number of any other record received during the session._
 
 _"Silently Discard" means the TOE discards the packet without responding._
-
-*FCS_DTLSC_EXT.3 DTLS Client Support for secure renegotiation (DTLSv1.2 only)*
-
-*FCS_DTLSC_EXT.3.1* The product shall support secure renegotiation through use of the “renegotiation_info” DTLS extension in accordance with RFC 5746.
-
-*_Application Note {counter:appnote_count}_*
-
-_This component may only be claimed for DTLS 1.2 but not DTLS 1.3._
-
-_RFC 5746 defines an extension to DTLS that binds renegotiation handshakes to the cryptography in the original handshake._
-
-_When performing secure renegotiation, the ”renegotiation_info” extension must be presented by the server initiating renegotiation, so the client must support use of this extension._
-
-_When signaling support for secure renegotiation, the client may present either the ”renegotiation_info” extension or the signaling cipher suite value TLS_EMPTY_RENEGOTIATION_INFO_SCSV in the initial ClientHello message. (A signaling cipher suite value (SCSV) is presented as a cipher suite, but its only purpose is to provide other information and not to advertise support for a cipher suite.) The TLS_EMPTY_RENEGOTIATION_INFO_SCSV signaling cipher suite value exists as an alternative to presenting the ”renegotation_info” extension so that DTLS server implementations that immediately terminate the connection when they encounter any extension they do not understand can still proceed with a connection. The client may still choose to reject the connection later, if it insists upon renegotiation support and the server does not support it._
 
 *FCS_DTLSS_EXT.2 DTLS Server Support for Mutual Authentication*
 
@@ -1943,20 +1921,11 @@ _The DTLS 1.2 Certificate Request message includes the algorithms as a list of  
 
 _The DTLS 1.3 Certificate Request message includes the algorithms as a list of  SignatureSchemes in the signature_algorithms extension._
 
-*FCS_DTLSS_EXT.3 TLS Server Support for secure renegotiation (DTLSv1.2 only)*
-
-*FCS_DTLSS_EXT.3.1* The product shall support secure renegotiation in accordance with RFC 5746 by always including the ”renegotiation_info” extension in ServerHello messages.
-
-*_Application Note {counter:appnote_count}_*
-
-_This component may only be claimed for DTLS 1.2 but not DTLS 1.3._
-
-_RFC 5746 defines an extension to DTLS that binds renegotiation handshakes to the cryptography in the original handshake in order to prevent an attack in which the attacker forms a DTLS connection with the target server, injects content of his choice, and then splices in a new DTLS connection from a client. The server treats the client’s initial DTLS handshake as a renegotiation and thus believes that the initial data transmitted by the attacker is from the same entity as the subsequent client data._
-
-
 =====  FCS_TLSC_EXT & FCS_TLSS_EXT TLS Protocol
 
-TLS is not a required component of this cPP. If a TOE implements TLS, a corresponding selection in FPT_ITT.1, FTP_ITC.1, or FTP_TRP.1/Admin should be made to define what the TLS protocol is implemented to protect. If a corresponding option to support TLS has been selected in at least one of the SFRs named above, the corresponding selection-based TLS-related SFRs should be added to the ST from chap. B.3.1.5 (i.e. FCS_TLSC_EXT.1 and/or FCS_TLSS_EXT.1). The SFRs therein cover only the minimum TLS-related requirements without support for mutual authentication. The support for mutual authentication is optional when using TLS. If a TOE implements TLS with mutual authentication, the corresponding optional SFRs should be added to the ST from chap. A.7.1.2 (i.e. FCS_TLSC_EXT.2 and/or FCS_TLSS_EXT.2) in addition to the corresponding SFRs from chap. B.3.1.5.
+TLS is not a required component of this cPP. If a TOE implements TLS, a corresponding selection in FPT_ITT.1, FTP_ITC.1, or FTP_TRP.1/Admin should be made to define what the TLS protocol is implemented to protect. If a corresponding option to support TLS has been selected in at least one of the SFRs named above, the corresponding selection-based TLS-related SFRs should be added to the ST from chap. B.3.1.5 (i.e. FCS_TLSC_EXT.1 and/or FCS_TLSS_EXT.1). The SFRs therein cover only the minimum TLS-related requirements without support for mutual authentication.
+
+The support for mutual authentication is optional when using TLS. If a TOE implements TLS with mutual authentication, the corresponding optional SFRs should be added to the ST from chap. A.7.1.2 (i.e. FCS_TLSC_EXT.2 and/or FCS_TLSS_EXT.2) in addition to the corresponding SFRs from chap. B.3.1.5.
 
 A TOE may act as the client, the server, or both in TLS sessions. The requirement has been separated into TLS Client (FCS_TLSC_EXT) and TLS Server (FCS_TLSS_EXT) requirements to allow for these differences. If the TOE acts as the client during the claimed TLS sessions, the ST author should claim the corresponding FCS_TLSC_EXT requirements. If the TOE acts as the server during the claimed TLS sessions, the ST author should claim the corresponding FCS_TLSS_EXT requirements. If the TOE acts as both a client and server during the claimed TLS sessions, the ST author should claim the corresponding FCS_TLSC_EXT and FCS_TLSS_EXT requirements.
 
@@ -1967,20 +1936,6 @@ A TOE may act as the client, the server, or both in TLS sessions. The requiremen
 *_Application Note {counter:appnote_count}_*
 
 _The use of X.509v3 certificates for TLS is addressed in FIA_X509_EXT.2.1. This requirement adds that the client must be capable of presenting a certificate to a TLS server for TLS mutual authentication._
-
-*FCS_TLSC_EXT.3 TLS Client Support for secure renegotiation (TLSv1.2 only)*
-
-*FCS_TLSC_EXT.3.1* The product shall support secure renegotiation through use of the “renegotiation_info” TLS extension in accordance with RFC 5746.
-
-*_Application Note {counter:appnote_count}_*
-
-_This component may only be claimed for TLS 1.2 but not TLS 1.3._
-
-_RFC 5746 defines an extension to TLS that binds renegotiation handshakes to the cryptography in the original handshake._
-
-_When performing secure renegotiation, the ”renegotiation_info” extension must be presented by the server initiating renegotiation, so the client must support use of this extension._
-
-_When signaling support for secure renegotiation, the client may present either the ”renegotiation_info” extension or the signaling cipher suite value TLS_EMPTY_RENEGOTIATION_INFO_SCSV in the initial ClientHello message. (A signaling cipher suite value (SCSV) is presented as a cipher suite, but its only purpose is to provide other information and not to advertise support for a cipher suite.) The TLS_EMPTY_RENEGOTIATION_INFO_SCSV signaling cipher suite value exists as an alternative to presenting the ”renegotation_info” extension so that TLS server implementations that immediately terminate the connection when they encounter any extension they do not understand can still proceed with a connection. The client may still choose to reject the connection later, if it insists upon renegotiation support and the server does not support it._
 
 *FCS_TLSS_EXT.2 TLS Server Support for Mutual Authentication*
 
@@ -2050,16 +2005,6 @@ _The selected ClientCertificateTypes and algorithms must be consistent with FCS_
 _The TLS 1.2 Certificate Request message includes the algorithms as a list of  SignatureAndHashAlgorithms in the supported signature algorithms list. The signature algorithm is also specified in the certificate_types list._
 
 _The TLS 1.3 Certificate Request message includes the algorithms as a list of SignatureSchemes in the signature_algorithms extension._
-
-*FCS_TLSS_EXT.3 TLS Server Support for secure renegotiation (TLSv1.2 only)*
-
-*FCS_TLSS_EXT.3.1* The product shall support secure renegotiation in accordance with RFC 5746 by always including the ”renegotiation_info” extension in ServerHello messages.
-
-*_Application Note {counter:appnote_count}_*
-
-_This component may only be claimed for TLS 1.2 but not TLS 1.3._
-
-_RFC 5746 defines an extension to TLS that binds renegotiation handshakes to the cryptography in the original handshake in order to prevent an attack in which the attacker forms a TLS connection with the target server, injects content of his choice, and then splices in a new TLS connection from a client.  The server treats the client's initial TLS handshake as a renegotiation and thus believes that the initial data transmitted by the attacker is from the same entity as the subsequent client data._
 
 === Optional Security Assurance Requirements for Flaw Remediation (ALC_FLR)
 
@@ -2353,6 +2298,18 @@ _The use of the early data extension and the post-handshake client authenticatio
 
 _The use of out-of-band provisioned pre-shared keys creates a potential security concern since the entropy used to generate the PSK is outside of the control of the TOE. PSKs are used in DTLS 1.3 to provide session resumption; however, in this case, the TSF is responsible for generating appropriately strong keying material.  Use of (EC)DHE further enhances security when using PSKs by providing forward secrecy._
 
+*FCS_DTLSC_EXT.1.9* The TSF shall [selection: _support DTLS 1.2 secure renegotiation through use of the “renegotiation_info” TLS extension in accordance with RFC 5746, reject [selection: DTLS 1.2, DTLS 1.3] renegotiation attempts_].
+
+*_Application Note {counter:appnote_count}_*
+
+_The ST author selects the first option if the TOE supports DTLS 1.2 and secure renegotiation is supported. The ST author selects the second option and “DTLS 1.2” if the TOE supports DTLS 1.2 and secure renegotiation is not supported. The second option and “DTLS 1.3” must be selected if the TOE supports DTLS 1.3._
+
+_RFC 5746 defines an extension to DTLS that binds renegotiation handshakes to the cryptography in the original handshake._
+
+_The “renegotiation_info” extension must be presented by the server to signal support for secure renegotiation and must be presented by the client to perform secure renegotiation._
+
+_When signaling support for secure renegotiation, the client may present either the “renegotiation_info” extension or the signaling cipher suite value TLS_EMPTY_RENEGOTIATION_INFO_SCSV in the initial ClientHello message. (A signaling cipher suite value (SCSV) is presented as a cipher suite, but its only purpose is to provide other information and not to advertise support for a cipher suite.) The TLS_EMPTY_RENEGOTIATION_INFO_SCSV signaling cipher suite value exists as an alternative to presenting the “renegotation_info” extension so that DTLS server implementations that immediately terminate the connection when they encounter any extension they do not understand can still proceed with a connection. The client may still choose to reject the connection later, if it insists upon renegotiation support and the server does not support it._
+
 *FCS_DTLSS_EXT.1 DTLS Server Protocol*
 
 *FCS_DTLSS_EXT.1.1* The TSF shall implement [selection: _DTLS 1.3 (RFC 9147), DTLS 1.2 (RFC 6347)_] and reject all other DTLS versions. The DTLS implementation will support the following ciphersuites:
@@ -2466,6 +2423,13 @@ _The use of the early data extension is prohibited in the configured TOE._
 
 _The use of out-of-band provisioned pre-shared keys creates a potential security concern since the entropy used to generate the PSK is outside of the control of the TOE.  PSKs are used in DTLS 1.3 to provide session resumption; however, in this case, the TSF is responsible for generating appropriately strong keying material.  Use of (EC)DHE further enhances security when using PSKs by providing forward secrecy._
 
+*FCS_DTLSS_EXT.1.11* The TSF shall [selection: _support secure renegotiation in accordance with RFC 5746 by always including the “renegotiation_info” TLS extension in DTLS 1.2 ServerHello messages, reject [selection: DTLS 1.2, DTLS 1.3] renegotiation attempts_].
+
+*_Application Note {counter:appnote_count}_*
+
+_The ST author selects the first option if the TOE supports DTLS 1.2 and secure renegotiation is supported. The ST author selects the second option and “DTLS 1.2” if the TOE supports DTLS 1.2 and secure renegotiation is not supported. The second option and “DTLS 1.3” must be selected if the TOE supports DTLS 1.3._
+
+_RFC 5746 defines an extension to DTLS that binds renegotiation handshakes to the cryptography in the original handshake in order to prevent an attack in which the attacker forms a DTLS connection with the target server, injects content of his choice, and then splices in a new DTLS connection from a client. The server treats the client’s initial DTLS handshake as a renegotiation and thus believes that the initial data transmitted by the attacker is from the same entity as the subsequent client data._
 
 =====  FCS_HTTPS_EXT HTTPS Protocol
 
@@ -2856,6 +2820,18 @@ _The use of the early data extension and the post-handshake client authenticatio
 
 _The use of out-of-band provisioned pre-shared keys creates a potential security concern since the entropy used to generate the PSK is outside of the control of the TOE.  PSKs are used in TLS 1.3 to provide session resumption; however, in this case, the TSF is responsible for generating appropriately strong keying material.  Use of (EC)DHE further enhances security when using PSKs by providing forward secrecy._
 
+*FCS_TLSC_EXT.1.9* The TSF shall [selection: _support TLS 1.2 secure renegotiation through use of the “renegotiation_info” TLS extension in accordance with RFC 5746, reject [selection: TLS 1.2, TLS 1.3] renegotiation attempts_].
+
+*_Application Note {counter:appnote_count}_*
+
+_The ST author selects the first option if the TOE supports TLS 1.2 and secure renegotiation is supported. The ST author selects the second option and “TLS 1.2” if the TOE supports TLS 1.2 and secure renegotiation is not supported. The second option and “TLS 1.3” must be selected if the TOE supports TLS 1.3._
+
+_RFC 5746 defines an extension to TLS that binds renegotiation handshakes to the cryptography in the original handshake._
+
+_The “renegotiation_info” extension must be presented by the server to signal support for secure renegotiation and must be presented by the client to perform secure renegotiation._
+
+_When signaling support for secure renegotiation, the client may present either the “renegotiation_info” extension or the signaling cipher suite value TLS_EMPTY_RENEGOTIATION_INFO_SCSV in the initial ClientHello message. (A signaling cipher suite value (SCSV) is presented as a cipher suite, but its only purpose is to provide other information and not to advertise support for a cipher suite.) The TLS_EMPTY_RENEGOTIATION_INFO_SCSV signaling cipher suite value exists as an alternative to presenting the “renegotation_info” extension so that TLS server implementations that immediately terminate the connection when they encounter any extension they do not understand can still proceed with a connection. The client may still choose to reject the connection later, if it insists upon renegotiation support and the server does not support it._
+
 *FCS_TLSS_EXT.1 TLS Server Protocol*
 
 *FCS_TLSS_EXT.1.1* The TSF shall implement [selection: _TLS 1.3 (RFC 8446), TLS 1.2 (RFC 5246)_] and reject all other TLS and SSL versions. The TLS implementation will support the following ciphersuites:
@@ -2948,6 +2924,13 @@ _The use of the early data extension is prohibited in the configured TOE._
 
 _The use of out-of-band provisioned pre-shared keys creates a potential security concern since the entropy used to generate the PSK is outside of the control of the TOE. PSKs are used in TLS 1.3 to provide session resumption; however, in this case, the TSF is responsible for generating appropriately strong keying material. Use of (EC)DHE further enhances security when using PSKs by providing forward secrecy._
 
+*FCS_TLSS_EXT.1.8* The TSF shall [selection: _support secure renegotiation in accordance with RFC 5746 by always including the “renegotiation_info” TLS extension in TLS 1.2 ServerHello messages, reject [selection: TLS 1.2, TLS 1.3] renegotiation attempts_].
+
+*_Application Note {counter:appnote_count}_*
+
+_The ST author selects the first option if the TOE supports TLS 1.2 and secure renegotiation is supported. The ST author selects the second option and “TLS 1.2” if the TOE supports TLS 1.2 and secure renegotiation is not supported. The second option and “TLS 1.3” must be selected if the TOE supports TLS 1.3._
+
+_RFC 5746 defines an extension to TLS that binds renegotiation handshakes to the cryptography in the original handshake in order to prevent an attack in which the attacker forms a TLS connection with the target server, injects content of his choice, and then splices in a new TLS connection from a client.  The server treats the client's initial TLS handshake as a renegotiation and thus believes that the initial data transmitted by the attacker is from the same entity as the subsequent client data._
 
 === Identification and Authentication (FIA)
 
@@ -3507,6 +3490,7 @@ _]._
 
 *FCS_DTLSC_EXT.1.8* The TSF shall not permit DTLS 1.3 connections using an out-of-band provisioned pre-shared key (PSK).  Any use of PSKs in DTLS 1.3 must use (EC)DHE to provide forward secrecy.
 
+*FCS_DTLSC_EXT.1.9* The TSF shall [selection: _support DTLS 1.2 secure renegotiation through use of the “renegotiation_info” TLS extension in accordance with RFC 5746, reject [selection: DTLS 1.2, DTLS 1.3] renegotiation attempts_].
 
 *FCS_DTLSC_EXT.2 DTLS Client Support for Mutual Authentication*
 
@@ -3534,26 +3518,6 @@ Dependencies:
 
 * DTLS records previously received;
 * DTLS records too old to fit in the sliding window.
-
-*FCS_DTLSC_EXT.3 DTLS Client Support for secure renegotiation (DTLSv1.2 only)*
-
-Hierarchical to: No other components
-
-Dependencies:
-
-* FCS_CKM.1Cryptographic Key Generation
-* FCS_CKM.2 Cryptographic Key Establishment
-* FCS_COP.1/DataEncryption Cryptographic operation (AES Data encryption/decryption)
-* FCS_COP.1/SigGen Cryptographic operation (Signature Generation and Verification)
-* FCS_COP.1/Hash Cryptographic operation (Hash Algorithm)
-* FCS_COP.1/KeyedHash Cryptographic operation (Keyed Hash Algorithm)
-* FCS_RBG_EXT.1 Random Bit Generation
-* FCS_DTLSC_EXT.1 TLS Client Protocol
-* FIA_X509_EXT.1 X.509 Certificate Validation
-* FIA_X509_EXT.2 X.509 Certificate Authentication
-* FIA_X509_EXT.3 X.509 Certificate Request
-
-*FCS_DTLSC_EXT.3.1* The product shall support secure renegotiation through use of the “renegotiation_info” TLS extension in accordance with RFC 5746.
 
 =====  FCS_DTLSS_EXT DTLS Server Protocol
 
@@ -3640,6 +3604,7 @@ Dependencies:
 
 *FCS_DTLSS_EXT.1.10* The TSF shall not permit DTLS 1.3 connections using an out-of-band provisioned pre-shared key (PSK).  Any use of PSKs in DTLS 1.3 must use (EC)DHE to provide forward secrecy.
 
+*FCS_DTLSS_EXT.1.11* The TSF shall [selection: _support secure renegotiation in accordance with RFC 5746 by always including the “renegotiation_info” TLS extension in DTLS 1.2 ServerHello messages, reject [selection: DTLS 1.2, DTLS 1.3] renegotiation attempts_].
 
 *FCS_DTLSS_EXT.2 DTLS Server Support for Mutual Authentication*
 
@@ -3693,25 +3658,6 @@ Dependencies:
 * _rsa_pss_pss with sha512(0x080b)_
 
 ] and no other algorithms.
-
-*FCS_DTLSS_EXT.3 TLS Server Support for secure renegotiation (DTLSv1.2 only)*
-
-Hierarchical to: No other components
-
-Dependencies:
-
-* FCS_CKM.1 Cryptographic Key Generation
-* FCS_CKM.2 Cryptographic Key Establishment
-* FCS_COP.1/DataEncryption Cryptographic operation (AES Data encryption/decryption)
-* FCS_COP.1/SigGen Cryptographic operation (Signature Generation and Verification)
-* FCS_COP.1/Hash Cryptographic operation (Hash Algorithm)
-* FCS_COP.1/KeyedHash Cryptographic operation (Keyed Hash Algorithm)
-* FCS_RBG_EXT.1 Random Bit Generation
-* FCS_DTLSS_EXT.1 DTLS Server Protocol
-* FIA_X509_EXT.1 X.509 Certificate Validation
-* FIA_X509_EXT.2 X.509 Certificate Authentication
-
-*FCS_DTLSS_EXT.3.1* The product shall support secure renegotiation in accordance with RFC 5746 by always including the ”renegotiation_info” extension in ServerHello messages.
 
 ===== FCS_HTTPS_EXT.1 HTTPS Protocol
 
@@ -4028,6 +3974,8 @@ _]._
 
 *FCS_TLSC_EXT.1.8* The TSF shall not permit TLS 1.3 connections using an out-of-band provisioned pre-shared key (PSK).  Any use of PSKs in TLS 1.3 must use (EC)DHE to provide forward secrecy.
 
+*FCS_TLSC_EXT.1.9* The TSF shall [selection: _support TLS 1.2 secure renegotiation through use of the “renegotiation_info” TLS extension in accordance with RFC 5746, reject [selection: TLS 1.2, TLS 1.3] renegotiation attempts_].
+
 *FCS_TLSC_EXT.2 TLS Client Support for Mutual Authentication*
 
 
@@ -4047,26 +3995,6 @@ Dependencies:
 * FIA_X509_EXT.2 X.509 Certificate Authentication
 
 *FCS_TLSC_EXT.2.1* The TSF shall support TLS communication with mutual authentication using X.509v3 certificates.
-
-*FCS_TLSC_EXT.3 TLS Client Support for secure renegotiation (TLSv1.2 only)*
-
-Hierarchical to: No other components
-
-Dependencies:
-
-* FCS_CKM.1Cryptographic Key Generation
-* FCS_CKM.2 Cryptographic Key Establishment
-* FCS_COP.1/DataEncryption Cryptographic operation (AES Data encryption/decryption)
-* FCS_COP.1/SigGen Cryptographic operation (Signature Generation and Verification)
-* FCS_COP.1/Hash Cryptographic operation (Hash Algorithm)
-* FCS_COP.1/KeyedHash Cryptographic operation (Keyed Hash Algorithm)
-* FCS_RBG_EXT.1 Random Bit Generation
-* FCS_TLSC_EXT.1 TLS Client Protocol
-* FIA_X509_EXT.1 X.509 Certificate Validation
-* FIA_X509_EXT.2 X.509 Certificate Authentication
-* FIA_X509_EXT.3 X.509 Certificate Request
-
-*FCS_TLSC_EXT.3.1* The product shall support secure renegotiation through use of the “renegotiation_info” TLS extension in accordance with RFC 5746.
 
 =====  FCS_TLSS_EXT TLS Server Protocol
 
@@ -4146,6 +4074,7 @@ Dependencies:
 
 *FCS_TLSS_EXT.1.7* The TSF shall not permit TLS 1.3 connections using an out-of-band provisioned pre-shared key (PSK).  Any use of PSKs in TLS 1.3 must use (EC)DHE to provide forward secrecy.
 
+*FCS_TLSS_EXT.1.8* The TSF shall [selection: _support secure renegotiation in accordance with RFC 5746 by always including the “renegotiation_info” TLS extension in TLS 1.2 ServerHello messages, reject [selection: TLS 1.2, TLS 1.3] renegotiation attempts_].
 
 *FCS_TLSS_EXT.2 TLS Server Support for Mutual Authentication*
 
@@ -4197,25 +4126,6 @@ Dependencies:
 * _rsa_pss_pss with sha512(0x080b)_
 
 ] and no other algorithms.
-
-*FCS_TLSS_EXT.3 TLS Server Support for secure renegotiation (TLSv1.2 only)*
-
-Hierarchical to: No other components
-
-Dependencies:
-
-* FCS_CKM.1 Cryptographic Key Generation
-* FCS_CKM.2 Cryptographic Key Establishment
-* FCS_COP.1/DataEncryption Cryptographic operation (AES Data encryption/decryption)
-* FCS_COP.1/SigGen Cryptographic operation (Signature Generation and Verification)
-* FCS_COP.1/Hash Cryptographic operation (Hash Algorithm)
-* FCS_COP.1/KeyedHash Cryptographic operation (Keyed Hash Algorithm)
-* FCS_RBG_EXT.1 Random Bit Generation
-* FCS_TLSS_EXT.1 TLS Server Protocol
-* FIA_X509_EXT.1 X.509 Certificate Validation
-* FIA_X509_EXT.2 X.509 Certificate Authentication
-
-*FCS_TLSS_EXT.3.1* The product shall support secure renegotiation in accordance with RFC 5746 by always including the ”renegotiation_info” extension in ServerHello messages.
 
 === Identification and Authentication (FIA)
 
@@ -4904,42 +4814,6 @@ FIA_X509_EXT.2 (selection-based SFR) included
 
 FIA_X509_EXT.3 (selection-based SFR) included
 
-|FCS_DTLSC_EXT.3 a|
-FCS_CKM.1
-
-FCS_CKM.2
-
-FCS_COP.1/DataEncryption
-
-FCS_COP.1/SigGen
-
-FCS_COP.1/Hash
-
-FCS_COP.1/KeyedHash
-
-FCS_RBG_EXT.1
-
-FIA_X509_EXT.1 X.509
-
-FIA_X509_EXT.2 X.509
-
-FIA_X509_EXT.3 X.509
-
-a|
-FCS_CKM.1 included
-
-FCS_CKM.2 included
-
-FCS_COP.1/DataEncryption, FCS_COP.1/SigGen, FCS_COP.1/Hash, FCS_COP.1/KeyedHash included
-
-FCS_RBG_EXT.1 included
-
-FIA_X509_EXT.1 (selection-based SFR) included
-
-FIA_X509_EXT.2 (selection-based SFR) included
-
-FIA_X509_EXT.3 (selection-based SFR) included
-
 |FCS_DTLSS_EXT.2 a|
 FCS_CKM.1
 
@@ -4976,78 +4850,7 @@ FIA_X509_EXT.2 (selection-based SFR) included
 
 FIA_X509_EXT.3 (selection-based SFR) included
 
-|FCS_DTLSS_EXT.3 a|
-FCS_CKM.1
-
-FCS_CKM.2
-
-FCS_COP.1/DataEncryption
-
-FCS_COP.1/SigGen
-
-FCS_COP.1/Hash
-
-FCS_COP.1/KeyedHash
-
-FCS_RBG_EXT.1
-
-FIA_X509_EXT.1 X.509
-
-FIA_X509_EXT.2 X.509
-
-FIA_X509_EXT.3 X.509
-
-a|
-FCS_CKM.1 included
-
-FCS_CKM.2 included
-
-FCS_COP.1/DataEncryption, FCS_COP.1/SigGen, FCS_COP.1/Hash, FCS_COP.1/KeyedHash included
-
-FCS_RBG_EXT.1 included
-
-FIA_X509_EXT.1 (selection-based SFR) included
-
-FIA_X509_EXT.2 (selection-based SFR) included
-
-FIA_X509_EXT.3 (selection-based SFR) included
 |FCS_TLSC_EXT.2 a|
-FCS_CKM.1
-
-FCS_CKM.2
-
-FCS_COP.1/DataEncryption
-
-FCS_COP.1/SigGen
-
-FCS_COP.1/Hash
-
-FCS_COP.1/KeyedHash
-
-FCS_RBG_EXT.1
-
-FIA_X509_EXT.1 X.509
-
-FIA_X509_EXT.2 X.509
-
-FIA_X509_EXT.3 X.509
-
-a|
-FCS_CKM.1 included
-
-FCS_CKM.2 included
-
-FCS_COP.1/DataEncryption, FCS_COP.1/SigGen, FCS_COP.1/Hash, FCS_COP.1/KeyedHash included
-
-FCS_RBG_EXT.1 included
-
-FIA_X509_EXT.1 (selection-based SFR) included
-
-FIA_X509_EXT.2 (selection-based SFR) included
-
-FIA_X509_EXT.3 (selection-based SFR) included
-
-|FCS_TLSC_EXT.3 a|
 FCS_CKM.1
 
 FCS_CKM.2
@@ -5119,41 +4922,6 @@ FIA_X509_EXT.2 (selection-based SFR) included
 
 FIA_X509_EXT.3 (selection-based SFR) included
 
-|FCS_TLSS_EXT.3 a|
-FCS_CKM.1
-
-FCS_CKM.2
-
-FCS_COP.1/DataEncryption
-
-FCS_COP.1/SigGen
-
-FCS_COP.1/Hash
-
-FCS_COP.1/KeyedHash
-
-FCS_RBG_EXT.1
-
-FIA_X509_EXT.1 X.509
-
-FIA_X509_EXT.2 X.509
-
-FIA_X509_EXT.3 X.509
-
-a|
-FCS_CKM.1 included
-
-FCS_CKM.2 included
-
-FCS_COP.1/DataEncryption, FCS_COP.1/SigGen, FCS_COP.1/Hash, FCS_COP.1/KeyedHash included
-
-FCS_RBG_EXT.1 included
-
-FIA_X509_EXT.1 (selection-based SFR) included
-
-FIA_X509_EXT.2 (selection-based SFR) included
-
-FIA_X509_EXT.3 (selection-based SFR) included
 |===
 
 [#_Toc456887396]#Table 11: SFR Dependencies Rationale for Optional SFRs#

--- a/NDcPP_v3_0.adoc
+++ b/NDcPP_v3_0.adoc
@@ -2156,11 +2156,21 @@ _These requirements will be revisited as new DTLS versions are standardized by t
 
 *_Application Note {counter:appnote_count}_*
 
-_Where DTLS is used for connections to or from non-TOE entities (relevant to FTP_ITC and FTP_TRP) the ST author shall select RFC 6125. For distributed TOEs (DTLS connections relevant to FPT_ITT), the ST author may select either RFC 6125 or RFC 5280. If RFC 5280 is selected, the selection is completed by listing the AttributeType (e.g. ‘id-at-serialNumber’) as defined in RFC 5280 Appendix A. The selection should only list those attributes that are significant (i.e. those which are used by the client for reference identifier matching), though the Subject field (DN) may contain other attribute types that are not significant for the purpose of reference identifier matching. In the TSS, the ST author describes which attribute type, or combination of attributes types, are used by the client to match the presented identifier with the configured identifier. The ST author selects “the reference identifier per RFC 6125 section 6” for TOEs that support FQDN, SRV, and URI identifiers._
+_Where DTLS is used for connections to or from non-TOE entities (relevant to FTP_ITC and FTP_TRP) the ST author shall select RFC 6125 and may select "IPv4 address..." or "IPv6 address...". The ST author shall not select RFC 5280._
 
-_The ST author selects “IPv4…” and/or “IPv6…” based on the IP versions the TOE supports. The ST author selects “CN or SAN” when IP addresses are supported in the “CN” or “SAN” when the TOE mandates the presence of the SAN. When “CN or SAN” is selected, the TOE only checks the CN when the certificate does not contain the SAN extension._
+_For distributed TOEs (DTLS connections relevant to FPT_ITT), the ST author may select any of the options. If RFC 5280 is selected, the selection is completed by listing the AttributeType (e.g. ‘id-at-serialNumber’) as defined in RFC 5280 Appendix A. The selection should only list those attributes that are significant (i.e. those which are used by the client for reference identifier matching), though the Subject field (DN) may contain other attribute types that are not significant for the purpose of reference identifier matching._
 
-_The rules for verification of identity are described in Section 6 of RFC 6125. Additionally, IP address identifiers may be supported in the SAN or CN. The reference identifier is established by the Administrator (e.g. entering a URL into a web browser or clicking a link), by configuration (e.g. configuring the name of a mail server or authentication server), or by an application (e.g. a parameter of an API) depending on the application service. Based on a singular reference identifier’s source domain or IP address and application service type (e.g. HTTP, SIP, LDAP), the client establishes all reference identifiers which are acceptable, such as a Common Name for the Subject Name field of the certificate and a (case-insensitive) DNS name, URI name, and Service Name for the Subject Alternative Name field. The client then compares this list of all acceptable reference identifiers to the presented identifiers in the TLS server’s certificate._
+_If IP address identifiers are supported, the ST author selects “IPv4…” and/or “IPv6…” based on the IP versions the TOE supports. The ST author selects “CN or SAN” when IP addresses are supported in the “CN” or “SAN” when the TOE mandates the presence of the SAN. When “CN or SAN” is selected, the TOE only checks the CN when the certificate does not contain the SAN extension._
+
+*_Application Note {counter:appnote_count}_*
+
+_The reference identifier is established by the Administrator (e.g. entering a URL into a web browser or clicking a link), by configuration (e.g. configuring the name of a mail server or authentication server), or by an application (e.g. a parameter of an API) depending on the application service. Based on a singular reference identifier’s source domain or IP address and application service type (e.g. HTTP, SIP, LDAP), the client establishes all reference identifiers which are acceptable, such as a Common Name for the Subject Name field of the certificate and a (case-insensitive) DNS name, URI name, and Service Name for the Subject Alternative Name field. The client then compares this list of all acceptable reference identifiers to the presented identifiers in the DTLS server’s certificate._
+
+_The rules for verification of DNS, URI, and Service identities are described in Section 6 of RFC 6125._
+
+_IP address identifiers may be supported in the SAN or CN. At this time, the cPP does not mandate a specific method of comparison; however, it is highly recommended that the IP addresses are convered to a binary representation in network byte order and a binary comprision is perfomred._
+
+_RFC 5280 identifiers are matched according to the TSS where the ST author describes which attribute type, or combination of attributes types, are used by the client to match the presented identifier with the configured identifier._
 
 _The preferred method for verification is the Subject Alternative Name using DNS names, URI names, or Service Names. Verification using the Common Name may be supported for the purposes of backwards compatibility. When the SAN extension is present in a certificate, the CN must be ignored._
 
@@ -2273,7 +2283,9 @@ _The option 'provides' shall be selected if the TOE provides the ability to conf
 
 *_Application Note {counter:appnote_count}_*
 
-_The use of the early data extension and the post-handshake client authentication is prohibited in the configured TOE. Prohibiting post-handshake client authentication might be dropped in a future version of NDcPP_
+_The use of the early data extension is prohibited in the configured TOE. The early data extension is a DTLS 1.3 extension. A TOE that only implments DTLS 1.2 vacuously meets the early data extension prohibition._
+
+_The use of the post-handshake client authentication is prohibited in the configured TOE. Prohibiting post-handshake client authentication might be dropped in a future version of NDcPP._
 
 *FCS_DTLSC_EXT.1.8* The TSF shall not permit DTLS 1.3 connections using an out-of-band provisioned pre-shared key (PSK).  Any use of PSKs in DTLS 1.3 must use (EC)DHE to provide forward secrecy.
 
@@ -2415,7 +2427,7 @@ _The option 'provides' shall be selected if the TOE provides the ability to conf
 
 *_Application Note {counter:appnote_count}_*
 
-_The use of the early data extension is prohibited in the configured TOE._
+_The use of the early data extension is prohibited in the configured TOE. The early data extension is a DTLS 1.3 extension. A TOE that only implments DTLS 1.2 vacuously meets the early data extension prohibition._
 
 *FCS_DTLSS_EXT.1.10* The TSF shall not permit DTLS 1.3 connections using an out-of-band provisioned pre-shared key (PSK).  Any use of PSKs in DTLS 1.3 must use (EC)DHE to provide forward secrecy.
 
@@ -2691,15 +2703,25 @@ _These requirements will be revisited as new TLS versions are standardized by th
 
 *_Application Note {counter:appnote_count}_*
 
-_Where TLS is used for connections to/from non-TOE entities (relevant to FTP_ITC and FTP_TRP), the ST author shall select RFC 6125. For distributed TOEs (TLS connections relevant to FPT_ITT), the ST author may select either RFC 6125 or RFC 5280. If RFC 5280 is selected, the selection is completed by listing the AttributeType (e.g. ‘id-at-serialNumber’) as defined in RFC 5280 Appendix A. The selection should only list those attributes that are significant (i.e. those which are used by the client for reference identifier matching), though the Subject field (DN) may contain other attribute types that are not significant for the purpose of reference identifier matching. In the TSS the ST author describes which attribute type, or combination of attributes types, are used by the client to match the presented identifier with the configured identifier. The ST author selects “the reference identifier per RFC 6125 section 6” for TOEs that support FQDN, SRV, and URI identifiers._
+_Where TLS is used for connections to or from non-TOE entities (relevant to FTP_ITC and FTP_TRP) the ST author shall select RFC 6125 and may select "IPv4 address..." or "IPv6 address...". The ST author shall not select RFC 5280._
 
-_The ST author selects “IPv4…” and/or “IPv6…” based on the IP versions the TOE supports. The ST author selects “CN or SAN” when IP addresses are supported in the “CN” or “SAN” when the TOE mandates the presence of the SAN. When “CN or SAN” is selected, the TOE only checks the CN when the certificate does not contain the SAN extension._
+_For distributed TOEs (TLS connections relevant to FPT_ITT), the ST author may select any of the options. If RFC 5280 is selected, the selection is completed by listing the AttributeType (e.g. ‘id-at-serialNumber’) as defined in RFC 5280 Appendix A. The selection should only list those attributes that are significant (i.e. those which are used by the client for reference identifier matching), though the Subject field (DN) may contain other attribute types that are not significant for the purpose of reference identifier matching._
 
-_The rules for verification of identity are described in Section 6 of RFC 6125. Additionally, IP address identifiers may be supported in the SAN or CN. The reference identifier is established by the Administrator (e.g. entering a URL into a web browser or clicking a link), by configuration (e.g. configuring the name of a mail server or authentication server), or by an application (e.g. a parameter of an API) depending on the application service. Based on a singular reference identifier’s source domain or IP address and application service type (e.g. HTTP, SIP, LDAP), the client establishes all reference identifiers which are acceptable, such as a Common Name for the Subject Name field of the certificate and a (case-insensitive) DNS name, URI name, and Service Name for the Subject Alternative Name field. The client then compares this list of all acceptable reference identifiers to the presented identifiers in the TLS server’s certificate._
+_If IP address identifiers are supported, the ST author selects “IPv4…” and/or “IPv6…” based on the IP versions the TOE supports. The ST author selects “CN or SAN” when IP addresses are supported in the “CN” or “SAN” when the TOE mandates the presence of the SAN. When “CN or SAN” is selected, the TOE only checks the CN when the certificate does not contain the SAN extension._
+
+*_Application Note {counter:appnote_count}_*
+
+_The reference identifier is established by the Administrator (e.g. entering a URL into a web browser or clicking a link), by configuration (e.g. configuring the name of a mail server or authentication server), or by an application (e.g. a parameter of an API) depending on the application service. Based on a singular reference identifier’s source domain or IP address and application service type (e.g. HTTP, SIP, LDAP), the client establishes all reference identifiers which are acceptable, such as a Common Name for the Subject Name field of the certificate and a (case-insensitive) DNS name, URI name, and Service Name for the Subject Alternative Name field. The client then compares this list of all acceptable reference identifiers to the presented identifiers in the TLS server’s certificate._
+
+_The rules for verification of DNS, URI, and Service identities are described in Section 6 of RFC 6125._
+
+_IP address identifiers may be supported in the SAN or CN. At this time, the cPP does not mandate a specific method of comparison; however, it is highly recommended that the IP addresses are convered to a binary representation in network byte order and a binary comprision is perfomred._
+
+_RFC 5280 identifiers are matched according to the TSS where the ST author describes which attribute type, or combination of attributes types, are used by the client to match the presented identifier with the configured identifier._
 
 _The preferred method for verification is the Subject Alternative Name using DNS names, URI names, or Service Names. Verification using the Common Name may be supported for the purposes of backwards compatibility. When the SAN extension is present in a certificate, the CN must be ignored._
 
-_Finally, the client should avoid constructing reference identifiers using wildcards. However, if the presented identifiers include wildcards and the TOE supports wildcard, the client must follow the best practices regarding matching; these best practices are captured in the evaluation activity. The exception being, the use of wildcards is not supported when using IP address as the reference identifier_
+_Finally, the client should avoid constructing reference identifiers using wildcards. However, if the presented identifiers include wildcards and the TOE supports wildcard, the client must follow the best practices regarding matching; these best practices are captured in the evaluation activity. The exception being, the use of wildcards is not supported when using IP address as the reference identifier._
 
 *FCS_TLSC_EXT.1.3* The TSF shall not establish a trusted channel if the server certificate is invalid [selection:
 
@@ -2812,7 +2834,9 @@ _The option 'provides' shall be selected if the TOE provides the ability to conf
 
 *_Application Note {counter:appnote_count}_*
 
-_The use of the early data extension and the post-handshake client authentication is prohibited in the configured TOE. Prohibiting post-handshake client authentication might be dropped in a future version of NDcPP._
+_The use of the early data extension is prohibited in the configured TOE. The early data extension is a TLS 1.3 extension. A TOE that only implments TLS 1.2 vacuously meets the early data extension prohibition._
+
+_The use of the post-handshake client authentication is prohibited in the configured TOE. Prohibiting post-handshake client authentication might be dropped in a future version of NDcPP._
 
 *FCS_TLSC_EXT.1.8* The TSF shall not permit TLS 1.3 connections using an out-of-band provisioned pre-shared key (PSK).  Any use of PSKs in TLS 1.3 must use (EC)DHE to provide forward secrecy.
 
@@ -2916,7 +2940,7 @@ _The option 'provides' shall be selected if the TOE provides the ability to conf
 
 *_Application Note {counter:appnote_count}_*
 
-_The use of the early data extension is prohibited in the configured TOE._
+_The use of the early data extension is prohibited in the configured TOE. The early data extension is a TLS 1.3 extension. A TOE that only implments TLS 1.2 vacuously meets the early data extension prohibition._
 
 *FCS_TLSS_EXT.1.7* The TSF shall not permit TLS 1.3 connections using an out-of-band provisioned pre-shared key (PSK). Any use of PSKs in TLS 1.3 must use (EC)DHE to provide forward secrecy.
 


### PR DESCRIPTION
resolves #302 by adding a application notes indicating (D)TLS 1.2 vacuously meets the prohibition of the use of TLS 1.3 extensions.
resolves #300 by clarifying reference identifiers. The application notes have been split in two, the first describing the valid selections. The second explain reference identifier matching.